### PR TITLE
[HOTFIX] DateTimeParseException 전역 예외 핸들러 복원 (#28)

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/global/advice/CustomRestControllerAdvice.java
+++ b/api/src/main/java/com/mediforme/mediforme/global/advice/CustomRestControllerAdvice.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 @Slf4j
@@ -48,6 +49,20 @@ public class CustomRestControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity
             .status(errorCode.getHttpStatus())
             .body(ApiResponse.onFailure(errorCode.getCode(), errorMessage));
+    }
+
+    /**
+     * 컨트롤러에서 LocalDate/LocalDateTime 문자열을 직접 파싱하다 실패한 경우
+     */
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<Object> handleDateTimeParseException(DateTimeParseException e) {
+        ErrorCode errorCode = ErrorCode.BAD_REQUEST;
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiResponse.onFailure(
+                errorCode.getCode(),
+                "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"
+            ));
     }
 
     /**


### PR DESCRIPTION
## 📌 개요

PR #27 에서 중복 `@RestControllerAdvice` 제거 과정에 `DateTimeParseException` 전용 핸들러가 함께 제거되어, 컨트롤러에서 `LocalDate.parse(...)` 직접 호출 시 발생하는 파싱 실패가 **400 → 500** 으로 회귀한 문제를 수정합니다.

## 🐛 재현

\`GET /users/me/statuses/week-summary?startDate=2025-13-45&endDate=2025-04-22\`

| 시점 | 응답 |
|---|---|
| PR #27 전 | \`400\` + \`COMMON400\` + \`"날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"\` |
| PR #27 후 (회귀) | \`500\` + \`COMMON500\` + \`"서버 에러, 관리자에게 문의 바랍니다."\` |
| 본 PR 후 (복원) | \`400\` + \`COMMON400\` + \`"날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"\` |

## 🔧 변경 사항

`CustomRestControllerAdvice` 에 `@ExceptionHandler(DateTimeParseException.class)` 추가. 응답 포맷·메시지를 이전 `ExceptionAdvice` 와 동일하게 복원.

## 🧪 테스트

\`\`\`
./gradlew :api:compileJava :api:test
→ BUILD SUCCESSFUL
\`\`\`

기존 \`RestControllerAdviceRegistrationTest\` 통과 (어드바이스는 여전히 1개).

## 🔗 관련 이슈

closes #28