### PR TITLE
[TEST] 핵심 도메인 단위 테스트 3종 추가 (Engine/Advice/SearchService) (#30)

### DIFF
--- a/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
@@ -1,0 +1,113 @@
+package com.mediforme.mediforme.check.engine;
+
+import com.mediforme.mediforme.check.port.InteractionRulePort;
+import com.mediforme.mediforme.medicine.dto.MedicineInteractResponseDto;
+import com.mediforme.mediforme.medicine.dto.MedicineInteractionDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InteractionEngineTest {
+
+    @Mock
+    private InteractionRulePort rulePort;
+
+    @InjectMocks
+    private InteractionEngine engine;
+
+    @Test
+    @DisplayName("사용자 복용 약이 비어있으면 경고도 없고 규칙 조회도 하지 않는다")
+    void evaluate_emptyUserMeds_returnsEmptyAndSkipsLookup() {
+        List<String> result = engine.evaluate(Collections.emptyList(), "아스피린");
+
+        assertThat(result).isEmpty();
+        verify(rulePort, never()).lookupByMedicineName(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("포트가 빈 규칙 리스트를 반환하면 경고 없음")
+    void evaluate_emptyRules_returnsEmpty() {
+        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
+            .userMedicineId(1L)
+            .medicineName("타이레놀")
+            .build();
+        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(Collections.emptyList());
+
+        List<String> result = engine.evaluate(List.of(userMed), "아스피린");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("interactionWarnings 에 새 약 이름이 포함되면 경고 메시지 생성")
+    void evaluate_warningContainsNewMedication_producesAlert() {
+        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
+            .userMedicineId(1L)
+            .medicineName("타이레놀")
+            .build();
+        MedicineInteractResponseDto rule = MedicineInteractResponseDto.builder()
+            .name("타이레놀")
+            .interactionWarnings("아세트아미노펜, 와파린")
+            .build();
+        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(rule));
+
+        List<String> result = engine.evaluate(List.of(userMed), "와파린");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0))
+            .contains("타이레놀")
+            .contains("와파린")
+            .contains("아세트아미노펜, 와파린");
+    }
+
+    @Test
+    @DisplayName("여러 약 × 여러 규칙 조합에서 매칭된 건수만 정확히 반환")
+    void evaluate_multipleMedsAndRules_returnsOnlyMatchedCount() {
+        MedicineInteractionDto tylenol = MedicineInteractionDto.builder()
+            .userMedicineId(1L).medicineName("타이레놀").build();
+        MedicineInteractionDto ibuprofen = MedicineInteractionDto.builder()
+            .userMedicineId(2L).medicineName("이부프로펜").build();
+
+        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(
+            MedicineInteractResponseDto.builder()
+                .name("타이레놀").interactionWarnings("아스피린").build(),
+            MedicineInteractResponseDto.builder()
+                .name("타이레놀").interactionWarnings("와파린").build()      // 매칭 안됨
+        ));
+        given(rulePort.lookupByMedicineName("이부프로펜")).willReturn(List.of(
+            MedicineInteractResponseDto.builder()
+                .name("이부프로펜").interactionWarnings("아스피린, 와파린").build()
+        ));
+
+        List<String> result = engine.evaluate(List.of(tylenol, ibuprofen), "아스피린");
+
+        // 타이레놀 첫 규칙 1건 + 이부프로펜 규칙 1건 = 2건
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("interactionWarnings 가 null 인 규칙은 NPE 없이 스킵")
+    void evaluate_nullWarnings_skipsWithoutNpe() {
+        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
+            .userMedicineId(1L).medicineName("타이레놀").build();
+        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(
+            MedicineInteractResponseDto.builder().name("타이레놀").interactionWarnings(null).build()
+        ));
+
+        List<String> result = engine.evaluate(List.of(userMed), "와파린");
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/global/advice/CustomRestControllerAdviceTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/global/advice/CustomRestControllerAdviceTest.java
@@ -1,0 +1,117 @@
+package com.mediforme.mediforme.global.advice;
+
+import com.mediforme.common.exception.CustomApiException;
+import com.mediforme.common.exception.ErrorCode;
+import com.mediforme.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.format.DateTimeParseException;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CustomRestControllerAdviceTest {
+
+    private final CustomRestControllerAdvice advice = new CustomRestControllerAdvice();
+
+    @Test
+    @DisplayName("CustomApiException 은 ErrorCode 의 httpStatus 와 code 를 그대로 내려준다")
+    void handleCustomApiException_returnsErrorCodeStatusAndCode() {
+        CustomApiException e = new CustomApiException(ErrorCode.USER_NOT_FOUND);
+
+        ResponseEntity<Object> response = advice.handleRestApiResponse(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.isSuccess()).isFalse();
+        assertThat(body.getCode()).isEqualTo("USER401");
+        assertThat(body.getMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("ConstraintViolationException 은 400 + 첫 위반 메시지")
+    void handleConstraintViolationException_returns400WithFirstMessage() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("휴대폰 번호 형식이 올바르지 않습니다.");
+        ConstraintViolationException e = new ConstraintViolationException(Set.of(violation));
+
+        ResponseEntity<Object> response = advice.handleConstraintViolationException(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo("COMMON400");
+        assertThat(body.getMessage()).isEqualTo("휴대폰 번호 형식이 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("MethodArgumentNotValidException 은 400 + 첫 FieldError 메시지")
+    void handleMethodArgumentNotValid_returns400WithFirstFieldError() {
+        BindingResult bindingResult = mock(BindingResult.class);
+        FieldError fieldError = new FieldError("dto", "name", "필수 필드입니다.");
+        when(bindingResult.getFieldError()).thenReturn(fieldError);
+
+        MethodArgumentNotValidException e = new MethodArgumentNotValidException(
+            mock(MethodParameter.class), bindingResult);
+
+        ResponseEntity<Object> response = advice.handleMethodArgumentNotValid(
+            e, new HttpHeaders(), HttpStatusCode.valueOf(400), mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo("COMMON400");
+        assertThat(body.getMessage()).isEqualTo("필수 필드입니다.");
+    }
+
+    @Test
+    @DisplayName("DateTimeParseException 은 400 + 날짜 형식 안내 메시지 (PR #29 회귀 방지)")
+    void handleDateTimeParseException_returns400WithDateFormatMessage() {
+        DateTimeParseException e = new DateTimeParseException("invalid", "2025-13-45", 0);
+
+        ResponseEntity<Object> response = advice.handleDateTimeParseException(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo("COMMON400");
+        assertThat(body.getMessage()).isEqualTo("날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)");
+    }
+
+    @Test
+    @DisplayName("DataIntegrityViolationException 은 409 + 중복 로그인 ID 에러코드")
+    void handleDataIntegrityViolation_returns409WithDuplicatedLoginIdCode() {
+        DataIntegrityViolationException e = new DataIntegrityViolationException("duplicate");
+
+        ResponseEntity<Object> response = advice.handleDataIntegrityViolation(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo("USER404");
+    }
+
+    @Test
+    @DisplayName("처리되지 않은 Exception 은 500 + COMMON500")
+    void handleException_returns500WithCommon500() {
+        Exception e = new RuntimeException("unexpected");
+
+        ResponseEntity<Object> response = advice.handleException(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo("COMMON500");
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
@@ -1,0 +1,66 @@
+package com.mediforme.mediforme.search.application;
+
+import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.medicine.dto.MedicineSearchResponseDto;
+import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MedicineSearchServiceTest {
+
+    @Mock
+    private MedicineSearchPort port;
+
+    @InjectMocks
+    private MedicineSearchService service;
+
+    @Test
+    @DisplayName("포트가 빈 리스트 반환 시 빈 응답 DTO 로 래핑")
+    void searchByName_emptyResult_returnsEmptyWrappedResponse() {
+        given(port.searchByName("없는약")).willReturn(Collections.emptyList());
+
+        MedicineSearchResponseDto response = service.searchByName("없는약");
+
+        assertThat(response).isNotNull();
+        assertThat(response.getMedicines()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("포트가 여러 항목 반환 시 순서 유지하여 그대로 래핑")
+    void searchByName_multipleItems_wrapsInOrder() {
+        List<MedicineSearchItemDto> items = List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").imageUrl("url1").build(),
+            MedicineSearchItemDto.builder().name("타이레놀펜").imageUrl("url2").build(),
+            MedicineSearchItemDto.builder().name("타이레놀콜드").imageUrl("url3").build()
+        );
+        given(port.searchByName("타이레")).willReturn(items);
+
+        MedicineSearchResponseDto response = service.searchByName("타이레");
+
+        assertThat(response.getMedicines())
+            .hasSize(3)
+            .containsExactlyElementsOf(items);
+    }
+
+    @Test
+    @DisplayName("포트에서 예외 발생 시 유스케이스가 swallow 없이 그대로 전파")
+    void searchByName_portThrows_propagatesException() {
+        RuntimeException boom = new RuntimeException("adapter failed");
+        given(port.searchByName("타이레놀")).willThrow(boom);
+
+        assertThatThrownBy(() -> service.searchByName("타이레놀"))
+            .isSameAs(boom);
+    }
+}


### PR DESCRIPTION
## 📌 개요

리팩터(PR #25 / #27 / #29) 이후 자동화 테스트가 `RestControllerAdviceRegistrationTest` 1개뿐이던 상태에서, port/adapter/engine 구조 덕에 Spring 없이 Mock 만으로 검증 가능한 핵심 로직부터 단위 테스트 안전망을 추가합니다.

## 🧪 추가된 테스트

### 1. `InteractionEngineTest` — 5 케이스
- 복용 약 비어있음 → 빈 결과 + 포트 호출 0회
- 포트가 빈 규칙 반환 → 경고 없음
- `interactionWarnings` 에 새 약 이름 포함 → 경고 문자열 생성
- 여러 약 × 여러 규칙 매트릭스 → 매칭된 건수만 정확히 반환
- `interactionWarnings` null → NPE 없이 스킵

### 2. `MedicineSearchServiceTest` — 3 케이스
- 포트가 빈 리스트 → 빈 응답 DTO 로 래핑
- 포트가 여러 항목 → 순서 유지하여 그대로 래핑
- 포트에서 예외 발생 → 유스케이스가 swallow 없이 그대로 전파

### 3. `CustomRestControllerAdviceTest` — 6 핸들러
- `CustomApiException(ErrorCode.USER_NOT_FOUND)` → 404 + `USER401`
- `ConstraintViolationException` → 400 + 첫 위반 메시지
- `MethodArgumentNotValidException` → 400 + 첫 FieldError 메시지
- **`DateTimeParseException` → 400 + `"날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"` (PR #29 회귀 방지)**
- `DataIntegrityViolationException` → 409 + `USER404`
- 일반 `Exception` → 500 + `COMMON500`

## ✅ 검증


```
./gradlew :api:test
→ BUILD SUCCESSFUL, 15 tests passed (신규 14 + 기존 1)
```


모든 테스트가 Spring context 로드 없이 1초 내 종료. DB/Redis/외부 API 의존 0.

## 🔗 관련 이슈

closes #30