### PR TITLE
[TEST] JWT 필터 / 토큰 프로바이더 / UserDetails 단위 테스트 추가 (#32)

### DIFF
--- a/api/src/test/java/com/mediforme/mediforme/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,182 @@
+package com.mediforme.mediforme.global.security.jwt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mediforme.common.exception.CustomApiException;
+import com.mediforme.common.exception.ErrorCode;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
+
+    @InjectMocks
+    private JwtAuthenticationFilter filter;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("토큰 없음 → 인증 설정 없이 다음 필터로 통과, 블랙리스트 조회 안함")
+    void doFilter_noToken_passesWithoutAuth() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        given(jwtTokenProvider.resolveToken(request)).willReturn(null);
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(tokenBlacklistService, never()).isTokenBlacklisted(anyString());
+    }
+
+    @Test
+    @DisplayName("제외 URL (/auth/login) → shouldNotFilter = true")
+    void shouldNotFilter_authEndpoint_returnsTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        assertThat(filter.shouldNotFilter(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("제외 URL (/swagger-ui/index.html) → shouldNotFilter = true")
+    void shouldNotFilter_swaggerUi_returnsTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/swagger-ui/index.html");
+        assertThat(filter.shouldNotFilter(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("보호 URL (/users/me) → shouldNotFilter = false")
+    void shouldNotFilter_protectedEndpoint_returnsFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        assertThat(filter.shouldNotFilter(request)).isFalse();
+    }
+
+    @Test
+    @DisplayName("정상 토큰 → SecurityContext 에 Authentication 설정 + ACCESS_TOKEN attribute 세팅")
+    void doFilter_validToken_setsAuthenticationAndAttribute() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        String token = "valid.jwt.token";
+        Authentication auth = new UsernamePasswordAuthenticationToken("user01", null, List.of());
+        given(jwtTokenProvider.resolveToken(request)).willReturn(token);
+        given(tokenBlacklistService.isTokenBlacklisted(token)).willReturn(false);
+        given(jwtTokenProvider.validateTokenOrThrow(token)).willReturn(true);
+        given(jwtTokenProvider.getAuthentication(token)).willReturn(auth);
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(auth);
+        assertThat(request.getAttribute(SecurityTokenAttributes.ACCESS_TOKEN)).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("블랙리스트 토큰 → 401 JSON 응답 (INVALID_JWT_TOKEN) + 체인 중단")
+    void doFilter_blacklistedToken_writes401Json() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        String token = "blacklisted.token";
+        given(jwtTokenProvider.resolveToken(request)).willReturn(token);
+        given(tokenBlacklistService.isTokenBlacklisted(token)).willReturn(true);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_JWT_TOKEN.getHttpStatus().value());
+        JsonNode body = new ObjectMapper().readTree(response.getContentAsString());
+        assertThat(body.get("success").asBoolean()).isFalse();
+        assertThat(body.get("code").asText()).isEqualTo(ErrorCode.INVALID_JWT_TOKEN.getCode());
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    @DisplayName("만료 토큰 → 401 JSON (EXPIRED_JWT_TOKEN)")
+    void doFilter_expiredToken_writes401Json() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        String token = "expired.token";
+        given(jwtTokenProvider.resolveToken(request)).willReturn(token);
+        given(tokenBlacklistService.isTokenBlacklisted(token)).willReturn(false);
+        given(jwtTokenProvider.validateTokenOrThrow(token))
+            .willThrow(new CustomApiException(ErrorCode.EXPIRED_JWT_TOKEN));
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.EXPIRED_JWT_TOKEN.getHttpStatus().value());
+        JsonNode body = new ObjectMapper().readTree(response.getContentAsString());
+        assertThat(body.get("code").asText()).isEqualTo(ErrorCode.EXPIRED_JWT_TOKEN.getCode());
+    }
+
+    @Test
+    @DisplayName("위조 토큰 → 401 JSON (INVALID_JWT_TOKEN)")
+    void doFilter_invalidToken_writes401Json() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        String token = "bad.token";
+        given(jwtTokenProvider.resolveToken(request)).willReturn(token);
+        given(tokenBlacklistService.isTokenBlacklisted(token)).willReturn(false);
+        given(jwtTokenProvider.validateTokenOrThrow(token))
+            .willThrow(new CustomApiException(ErrorCode.INVALID_JWT_TOKEN));
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_JWT_TOKEN.getHttpStatus().value());
+        JsonNode body = new ObjectMapper().readTree(response.getContentAsString());
+        assertThat(body.get("code").asText()).isEqualTo(ErrorCode.INVALID_JWT_TOKEN.getCode());
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 → 500 JSON (COMMON500)")
+    void doFilter_unexpectedError_writes500Json() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        given(jwtTokenProvider.resolveToken(request)).willThrow(new RuntimeException("boom"));
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus())
+            .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value());
+        JsonNode body = new ObjectMapper().readTree(response.getContentAsString());
+        assertThat(body.get("code").asText()).isEqualTo("COMMON500");
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/global/security/jwt/JwtTokenProviderTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/global/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,210 @@
+package com.mediforme.mediforme.global.security.jwt;
+
+import com.mediforme.common.exception.CustomApiException;
+import com.mediforme.common.exception.ErrorCode;
+import com.mediforme.mediforme.global.security.CustomUserDetails;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "test-secret-for-jwt-provider-at-least-32-bytes-long-please";
+    private static final long ACCESS_EXP_MS = 60_000L;
+    private static final long REFRESH_EXP_MS = 300_000L;
+
+    @Mock
+    private UserDetailsServiceImpl userDetailsService;
+
+    private JwtTokenProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new JwtTokenProvider(userDetailsService);
+        ReflectionTestUtils.setField(provider, "secretKey", SECRET);
+        ReflectionTestUtils.setField(provider, "accessExpirationTime", ACCESS_EXP_MS);
+        ReflectionTestUtils.setField(provider, "refreshExpirationTime", REFRESH_EXP_MS);
+    }
+
+    @Test
+    @DisplayName("Access Token 발급 후 subject/uid claim 정상 추출")
+    void createAccessToken_claimsAccessible() {
+        String token = provider.createAccessToken(42L, "user01", 1001L);
+
+        assertThat(provider.getUserLoginIdFromToken(token)).isEqualTo("user01");
+        assertThat(provider.getUserIdClaim(token)).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("Refresh Token 도 동일한 서명/subject 로 생성")
+    void createRefreshToken_parseable() {
+        String token = provider.createRefreshToken(42L, "user01", 1001L);
+
+        assertThat(provider.getUserLoginIdFromToken(token)).isEqualTo("user01");
+        assertThat(provider.getUserIdClaim(token)).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("TTL 은 생성 직후 accessExpirationTime 근사값")
+    void getRemainingTtlMs_nearExpirationTime() {
+        String token = provider.createAccessToken(1L, "u", 1001L);
+
+        long ttl = provider.getRemainingTtlMs(token);
+
+        assertThat(ttl).isBetween(ACCESS_EXP_MS - 1_000L, ACCESS_EXP_MS);
+    }
+
+    @Test
+    @DisplayName("validateTokenOrThrow: 정상 토큰은 true")
+    void validateToken_valid_returnsTrue() {
+        String token = provider.createAccessToken(1L, "u", 1001L);
+
+        assertThat(provider.validateTokenOrThrow(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("validateTokenOrThrow: 다른 키로 서명한 위조 토큰은 INVALID_JWT_TOKEN")
+    void validateToken_tampered_throwsInvalid() {
+        Key otherKey = new SecretKeySpec(
+            "another-secret-that-is-also-at-least-32-bytes-long".getBytes(StandardCharsets.UTF_8),
+            "HmacSHA256");
+        String forged = Jwts.builder()
+            .setSubject("u")
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + 60_000))
+            .signWith(otherKey, SignatureAlgorithm.HS256)
+            .compact();
+
+        assertThatThrownBy(() -> provider.validateTokenOrThrow(forged))
+            .isInstanceOf(CustomApiException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_JWT_TOKEN);
+    }
+
+    @Test
+    @DisplayName("validateTokenOrThrow: 만료된 토큰은 EXPIRED_JWT_TOKEN")
+    void validateToken_expired_throwsExpired() {
+        Key key = new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        String expired = Jwts.builder()
+            .setSubject("u")
+            .setIssuedAt(new Date(System.currentTimeMillis() - 120_000))
+            .setExpiration(new Date(System.currentTimeMillis() - 60_000))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+
+        assertThatThrownBy(() -> provider.validateTokenOrThrow(expired))
+            .isInstanceOf(CustomApiException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_JWT_TOKEN);
+    }
+
+    @Test
+    @DisplayName("validateTokenOrThrow: 형식이 잘못된 토큰은 INVALID_JWT_TOKEN")
+    void validateToken_malformed_throwsInvalid() {
+        assertThatThrownBy(() -> provider.validateTokenOrThrow("not.a.jwt"))
+            .isInstanceOf(CustomApiException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_JWT_TOKEN);
+    }
+
+    @Test
+    @DisplayName("resolveToken: Bearer prefix 가 있으면 토큰 부분만 추출")
+    void resolveToken_bearerPrefix_returnsToken() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer abc.def.ghi");
+
+        assertThat(provider.resolveToken(request)).isEqualTo("abc.def.ghi");
+    }
+
+    @Test
+    @DisplayName("resolveToken: Authorization 헤더 없으면 null")
+    void resolveToken_noHeader_returnsNull() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("Authorization")).willReturn(null);
+
+        assertThat(provider.resolveToken(request)).isNull();
+    }
+
+    @Test
+    @DisplayName("resolveToken: 잘못된 prefix 면 null")
+    void resolveToken_wrongPrefix_returnsNull() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("Authorization")).willReturn("Basic abc");
+
+        assertThat(provider.resolveToken(request)).isNull();
+    }
+
+    @Test
+    @DisplayName("getAuthentication: 정상(ACTIVE) 사용자 → UsernamePasswordAuthenticationToken")
+    void getAuthentication_activeUser_returnsAuthenticationToken() {
+        CustomUserDetails active = CustomUserDetails.builder()
+            .userId(1L)
+            .userLoginId("user01")
+            .password("pw")
+            .roleCd(1001L)
+            .statusCd(2001L)
+            .authorities(List.of())
+            .build();
+        given(userDetailsService.loadUserByUsername("user01")).willReturn(active);
+
+        String token = provider.createAccessToken(1L, "user01", 1001L);
+        Authentication auth = provider.getAuthentication(token);
+
+        assertThat(auth).isInstanceOf(UsernamePasswordAuthenticationToken.class);
+        assertThat(auth.getPrincipal()).isSameAs(active);
+    }
+
+    @Test
+    @DisplayName("getAuthentication: 탈퇴(9999) 사용자 → USER_RESIGNED")
+    void getAuthentication_resignedUser_throwsUserResigned() {
+        CustomUserDetails resigned = CustomUserDetails.builder()
+            .userId(1L)
+            .userLoginId("user01")
+            .roleCd(1001L)
+            .statusCd(9999L)
+            .authorities(List.of())
+            .build();
+        given(userDetailsService.loadUserByUsername("user01")).willReturn(resigned);
+
+        String token = provider.createAccessToken(1L, "user01", 1001L);
+
+        assertThatThrownBy(() -> provider.getAuthentication(token))
+            .isInstanceOf(CustomApiException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.USER_RESIGNED);
+    }
+
+    @Test
+    @DisplayName("getAuthentication: isEnabled=true 인데 잠금 상태면 COMMON_UNAUTHORIZED")
+    void getAuthentication_lockedButEnabled_throwsUnauthorized() {
+        // 실제 status 조합으로는 도달 불가능해서 override 로 재현
+        CustomUserDetails locked = new CustomUserDetails() {
+            @Override public boolean isEnabled() { return true; }
+            @Override public boolean isAccountNonLocked() { return false; }
+        };
+        given(userDetailsService.loadUserByUsername("user01")).willReturn(locked);
+
+        String token = provider.createAccessToken(1L, "user01", 1001L);
+
+        assertThatThrownBy(() -> provider.getAuthentication(token))
+            .isInstanceOf(CustomApiException.class)
+            .extracting("errorCode").isEqualTo(ErrorCode.COMMON_UNAUTHORIZED);
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/global/security/jwt/UserDetailsServiceImplTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/global/security/jwt/UserDetailsServiceImplTest.java
@@ -1,0 +1,68 @@
+package com.mediforme.mediforme.global.security.jwt;
+
+import com.mediforme.mediforme.global.security.CustomUserDetails;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserDetailsServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @DisplayName("정상 사용자 조회 → CustomUserDetails 로 래핑하고 필드 매핑 정확")
+    void loadUserByUsername_existingUser_returnsCustomUserDetails() {
+        User user = User.builder()
+            .userId(42L)
+            .userLoginId("user01")
+            .userName("홍길동")
+            .password("hashed-pw")
+            .phone("010-1111-2222")
+            .roleCd(1001L)
+            .consentCd(1L)
+            .statusCd(2001L)
+            .build();
+        given(userRepository.findByUserLoginId("user01")).willReturn(Optional.of(user));
+
+        UserDetails details = userDetailsService.loadUserByUsername("user01");
+
+        assertThat(details).isInstanceOf(CustomUserDetails.class);
+        CustomUserDetails cud = (CustomUserDetails) details;
+        assertThat(cud.getUserId()).isEqualTo(42L);
+        assertThat(cud.getUsername()).isEqualTo("user01");
+        assertThat(cud.getPassword()).isEqualTo("hashed-pw");
+        assertThat(cud.getStatusCd()).isEqualTo(2001L);
+        assertThat(cud.isEnabled()).isTrue();
+        assertThat(cud.getAuthorities())
+            .extracting(a -> a.getAuthority())
+            .containsExactly("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 → UsernameNotFoundException")
+    void loadUserByUsername_nonExisting_throwsUsernameNotFound() {
+        given(userRepository.findByUserLoginId("ghost")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userDetailsService.loadUserByUsername("ghost"))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("User not found");
+    }
+}


### PR DESCRIPTION
## 📌 개요

PR #31 (핵심 도메인 단위 테스트) 에 이어, User 플로우 안정성의 핵심인 **JWT 인증 레이어** 단위 테스트를 추가합니다.

port/adapter 추상화가 없는 계층이라 `ReflectionTestUtils` 로 `@Value` 필드 주입이 필요하지만, 여전히 Spring context 로드 없이 Mockito + `MockHttpServletRequest/Response` 만으로 단위 테스트 완결.

## 🧪 추가된 테스트

### 1. `JwtTokenProviderTest` — 13 케이스
- Access/Refresh 토큰 발급 후 `subject` / `uid` claim 추출
- TTL 근사값 검증
- `validateTokenOrThrow`: 정상 / 위조(다른 키) / 만료 / 형식 오류
- `resolveToken`: `Bearer xxx` / 헤더 없음 / 잘못된 prefix
- `getAuthentication`: 정상(ACTIVE) / 탈퇴(9999, `USER_RESIGNED`) / 잠금(`COMMON_UNAUTHORIZED`)

### 2. `JwtAuthenticationFilterTest` — 9 케이스
- 토큰 없음 → 인증 없이 다음 필터로 통과 + 블랙리스트 조회 생략
- `shouldNotFilter`: `/auth/login`, `/swagger-ui/**` → true / `/users/me` → false
- 정상 토큰 → `SecurityContext` + `ACCESS_TOKEN` attribute 설정
- 블랙리스트 토큰 → 401 JSON + `INVALID_JWT_TOKEN` + 체인 중단
- 만료 토큰 → 401 JSON + `EXPIRED_JWT_TOKEN`
- 위조 토큰 → 401 JSON + `INVALID_JWT_TOKEN`
- 예상치 못한 예외 → 500 JSON + `COMMON500`
- 응답 바디가 `ApiResponse.onFailure` 포맷 (success/code/message) 준수

### 3. `UserDetailsServiceImplTest` — 2 케이스
- 정상 사용자 → `CustomUserDetails` 래핑 + 필드 매핑 + `ROLE_USER` 권한
- 미존재 사용자 → `UsernameNotFoundException("User not found")`

## ✅ 검증


```
./gradlew :api:test
→ BUILD SUCCESSFUL, 39 tests passed (신규 24 + 기존 15)
```


모든 테스트가 Spring context 로드 없이 수 초 내 종료. DB/Redis/외부 API 의존 0.

## 🔗 관련 이슈

closes #32

## 💡 PR #21 회귀 방지 포인트

탈퇴 사용자 접근 차단 정책(`USER_RESIGNED` 예외) 을 `JwtTokenProvider.getAuthentication` 테스트에서 명시적으로 검증 → 향후 인증 로직 변경 시 해당 정책이 깨지면 즉시 빌드 실패로 감지 가능.