### PR TITLE
[TEST] Spring Application Context 로드 스모크 테스트 + app 모듈 테스트 인프라 구축 (#34)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,12 @@ plugins {
 dependencies {
     // 부트스트랩 모듈 — api 모듈을 실행 가능한 Spring Boot 앱으로 패키징
     implementation project(':api')
+
+    // 테스트 — 전체 Spring context 로드 검증용
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'com.google.cloud:google-cloud-vision:3.45.0'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 // 이 모듈만 실행 가능한 boot jar 를 생성

--- a/app/src/test/java/com/mediforme/mediforme/MediformeApplicationTests.java
+++ b/app/src/test/java/com/mediforme/mediforme/MediformeApplicationTests.java
@@ -1,0 +1,54 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.mediforme.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 전체 Spring context 가 오류 없이 기동되는지 검증하는 스모크 테스트
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class MediformeApplicationTests {
+
+    @MockBean
+    private ImageAnnotatorClient imageAnnotatorClient;
+
+    @MockBean
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private List<SecurityFilterChain> securityFilterChains;
+
+    @Test
+    @DisplayName("전체 Spring context 가 정상 기동 (bean wiring / auditing / @RestControllerAdvice 등록 검증)")
+    void contextLoads() {
+        assertThat(securityFilterChains).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("SecurityFilterChain 에 JwtAuthenticationFilter 가 등록되어 있다")
+    void securityFilterChain_containsJwtAuthenticationFilter() {
+        boolean hasJwtFilter = securityFilterChains.stream()
+            .filter(DefaultSecurityFilterChain.class::isInstance)
+            .map(DefaultSecurityFilterChain.class::cast)
+            .flatMap(chain -> chain.getFilters().stream())
+            .anyMatch(JwtAuthenticationFilter.class::isInstance);
+
+        assertThat(hasJwtFilter)
+            .as("보안 체인에 JwtAuthenticationFilter 가 등록되어야 함")
+            .isTrue();
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -1,0 +1,38 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: false
+        format_sql: false
+
+  # Redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  cache:
+    type: none
+
+# application.yml 및 application-jwt.yml 의 placeholder 를 resolve 하기 위한 dummy 값
+JWT_SECRET_KEY: test-jwt-secret-at-least-32-bytes-long-for-hmac-sha-256
+JWT_ACCESS_EXPIRATION: 3600000
+JWT_REFRESH_EXPIRATION: 604800000
+MFDS_API_KEY: test-mfds-key
+GOOGLE_APPLICATION_CREDENTIALS: /tmp/nonexistent-test-credentials
+COOLSMS_API_KEY: test
+COOLSMS_API_SECRET: test
+COOLSMS_API_SENDER: "01011112222"


### PR DESCRIPTION
## 📌 개요

PR #31 / #33 의 단위 테스트 커버리지에 이어, 전체 Spring context 가 오류 없이 기동되는지 검증하는 **통합 레벨 스모크 테스트**를 추가합니다.

단위 테스트가 잡을 수 없던 회귀 범주를 커버합니다:
- Spring bean 순환 의존 / 누락 / 타입 충돌
- `SecurityFilterChain` 구성 실수 (JWT 필터 체인 누락 등)
- `@EnableJpaAuditing` / `@EnableRedisRepositories` 설정 파손
- `application.yml` 프로퍼티 placeholder 누락
- `@RestControllerAdvice` 중복 재발 (런타임 bean 기준)

## 🧪 추가된 테스트 & 인프라

### 1. app 모듈 테스트 인프라 (신설)
- `app/build.gradle`: `spring-boot-starter-test`, `spring-boot-starter-security`, `google-cloud-vision` (testImpl) + `h2` (testRuntimeOnly) 추가
- `app/src/test/resources/application-test.yml`: H2 메모리 DB + Redis/캐시 비활성 + JWT/MFDS/GCP/CoolSMS placeholder dummy 값

### 2. `MediformeApplicationTests` — 2 케이스
- `contextLoads()` — 전체 Spring context 정상 기동 (`SecurityFilterChain` 주입 성공으로 확인)
- `securityFilterChain_containsJwtAuthenticationFilter()` — 보안 체인에 `JwtAuthenticationFilter` 가 실제로 등록되어 있는지 런타임 수준 검증

## 🔧 외부 리소스 차단 전략

| 리소스 | 대체 방법 |
|---|---|
| MySQL | H2 (`jdbc:h2:mem:testdb;MODE=MySQL`) |
| Redis | `@MockBean RedisConnectionFactory` (연결 시도 회피, `@EnableRedisRepositories` 는 유지해서 bean wiring 은 실제와 동일) |
| GCP Vision | `@MockBean ImageAnnotatorClient` (기동 시 credentials 조회 회피) |
| MFDS/FDA/RxNorm | dummy URL / key (실제 호출 없음) |
| CoolSMS | dummy key/secret/sender |

## ✅ 검증


```
./gradlew :app:test
→ BUILD SUCCESSFUL, 2 tests passed in 59ms
```


전체 모듈 기준:
```
./gradlew :common:test :api:test :app:test
→ BUILD SUCCESSFUL, 41 tests passed (기존 39 + 신규 2)
```


## 📝 설계 노트

- **api 의존성이 `implementation` 스코프라** app 테스트가 `com.google.cloud.vision` / `spring-security-web` 타입을 참조하려면 `testImplementation` 으로 명시 추가 필요. api 를 `java-library` 로 둔 원칙(구현 상세 캡슐화) 을 유지하면서 테스트 요구만 국소적으로 해결.
- Redis 를 완전히 제외하는 대신 `@MockBean` 으로 덮어씀 → `@EnableRedisRepositories` 는 유지한 채 연결 시도만 차단하므로 bean wiring 은 production 과 거의 동일.

## 🔗 관련 이슈

closes #34