### PR TITLE
[CHORE] ErrorCode enum 내 status/code 불일치 항목 정돈 (#38)

### DIFF
--- a/common/src/main/java/com/mediforme/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/mediforme/common/exception/ErrorCode.java
@@ -12,8 +12,6 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     COMMON_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     COMMON_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON402", "금지된 요청입니다."),
-    UNAUTHORIZED_MODIFY(HttpStatus.BAD_REQUEST, "COMMON403", "수정, 삭제 권한이 없습니다."),
-    USER_NOT_ADMIN(HttpStatus.UNAUTHORIZED, "COMMON403", "관리자만 사용 가능한 API입니다."),
     UNKNOWN_INQUIRY_TYPE(HttpStatus.BAD_REQUEST, "COMMON405", "알 수 없는 조회 타입입니다."),
 
     // User


### PR DESCRIPTION
## 📌 개요

PR #37 의 "함께 발견된 선재 이슈" 섹션에서 flag 한 `ErrorCode` enum 내 불일치 항목 정돈.

두 entry 모두 **usage 0건** (전수 grep 확인) 이면서 동시에 status/code/네이밍이 어긋난 상태. 다음 개발자가 실수로 쓰면 잘못된 HTTP status 를 내려줄 위험이 있어 제거.

## 🗑️ 제거 대상

```
UNAUTHORIZED_MODIFY(HttpStatus.BAD_REQUEST, "COMMON403", "수정, 삭제 권한이 없습니다."),
USER_NOT_ADMIN    (HttpStatus.UNAUTHORIZED, "COMMON403", "관리자만 사용 가능한 API입니다."),
```

| 항목 | 문제 |
|---|---|
| `UNAUTHORIZED_MODIFY` | name/code 는 403 을 시사하지만 status 는 400. 메시지는 전형적 403 의미. |
| `USER_NOT_ADMIN` | name/메시지는 403, 그러나 status 401. code `"COMMON403"` 이 `UNAUTHORIZED_MODIFY` 와 중복. |

## 대체

- `FORBIDDEN_ACTION(HttpStatus.FORBIDDEN, "ACTION403", "접근 권한이 없습니다.")` 가 generic 403 케이스 커버
- "수정/삭제 권한 없음" 이나 "관리자 전용" 같은 specific 에러 코드가 실제 필요해지면 그때 올바른 status 로 재도입

## ✅ 검증


```
./gradlew :common:test :api:test :app:test
→ BUILD SUCCESSFUL, 43 tests passed
```


## 🔗 관련 이슈

closes #38