### PR TITLE
[FEAT] Spring Boot Actuator + Micrometer(Prometheus) 관측성 기반 도입 (#40)

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-actuator'
 
     api project(':common')
     api project(':lib:redis')

--- a/api/src/main/java/com/mediforme/mediforme/global/security/SecurityConfig.java
+++ b/api/src/main/java/com/mediforme/mediforme/global/security/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/favicon.ico",
                                 "/error",
-                                "/auth/**"
+                                "/auth/**",
+                                "/actuator/**"
                         ).permitAll()
                     
                         // 온보딩/조회성 API는 GET만 공개

--- a/api/src/main/java/com/mediforme/mediforme/global/security/jwt/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/mediforme/mediforme/global/security/jwt/JwtAuthenticationFilter.java
@@ -52,6 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/auth/**",             // 로그인, 회원가입, 토큰 재발급
             "/find/**",             // 아이디/비밀번호 찾기
 
+            // Actuator (관측성 엔드포인트)
+            "/actuator/**",
+
             // 정적 리소스
             "/favicon.ico",
             "/error"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     // 부트스트랩 모듈 — api 모듈을 실행 가능한 Spring Boot 앱으로 패키징
     implementation project(':api')
 
+    // 메트릭 레지스트리
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // 테스트 — 전체 Spring context 로드 검증용
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security'

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -52,3 +52,16 @@ coolsms:
     key: ${COOLSMS_API_KEY:}
     secret: ${COOLSMS_API_SECRET:}
     sender: ${COOLSMS_API_SENDER:}
+
+# Actuator / Micrometer
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+  metrics:
+    tags:
+      application: mediforme

--- a/app/src/test/java/com/mediforme/mediforme/ActuatorHealthSmokeTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/ActuatorHealthSmokeTest.java
@@ -1,0 +1,50 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Actuator 엔드포인트가 인증 없이 정상 노출되는지 검증하는 스모크 테스트
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ActuatorHealthSmokeTest {
+
+    @MockBean
+    private ImageAnnotatorClient imageAnnotatorClient;
+
+    @MockBean
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("/actuator/health 는 인증 없이 200 + status UP 반환")
+    void health_isPublic_andReportsUp() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/health", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("JWT 보호 엔드포인트는 여전히 401 반환 (회귀 방지)")
+    void protectedEndpoint_stillRequiresAuth() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/users/me", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).contains("JWT401");
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -27,6 +27,12 @@ spring:
   cache:
     type: none
 
+# Actuator health
+management:
+  health:
+    redis:
+      enabled: false
+
 # application.yml 및 application-jwt.yml 의 placeholder 를 resolve 하기 위한 dummy 값
 JWT_SECRET_KEY: test-jwt-secret-at-least-32-bytes-long-for-hmac-sha-256
 JWT_ACCESS_EXPIRATION: 3600000


### PR DESCRIPTION
## 📌 개요

리팩터(PR #25 ~ #37) 와 테스트 안전망(PR #31/#33/#35) 을 마친 뒤의 관측성 기반 도입.
성능 작업(캐시, 병렬 호출, 비동기 처리 등) 이전에 **측정 수단을 먼저 확보**하는 것이 목적.

## 🎯 도입한 것

### 1. 의존성 분리
| 모듈 | 스코프 | 패키지 | 이유 |
|---|---|---|---|
| `api/build.gradle` | `api` | `spring-boot-starter-actuator` | 모든 모듈에서 actuator 인프라 공용 |
| `app/build.gradle` | `runtimeOnly` | `io.micrometer:micrometer-registry-prometheus` | 배포 단위별 exporter 선택 (Prometheus/Datadog/NewRelic 등) |

### 2. 노출 엔드포인트
```
management:
  endpoints:
    web:
      exposure:
        include: health,info,prometheus
  endpoint:
    health:
      show-details: when-authorized
  metrics:
    tags:
      application: mediforme
```

### 3. 인증/인가 설정
- `SecurityConfig` 에 `/actuator/**` permitAll
- `JwtAuthenticationFilter.EXCLUDE_URLS` 에 `/actuator/**` 추가

## 로컬 bootRun 검증
```
GET /actuator/health     → 200 {"status":"UP"}
GET /actuator/info       → 200 {}
GET /actuator/prometheus → 200 # HELP application_ready_time_seconds ... (application="mediforme" 공통 태그 포함)
GET /users/me (토큰없음)  → 401 {"success":false,"code":"JWT401",...}   # 회귀 없음
```


## 자동 테스트

`ActuatorHealthSmokeTest` — `@SpringBootTest(webEnvironment = RANDOM_PORT)` 2 케이스:
- `/actuator/health` → 200 + `status=UP`
- 보호 엔드포인트 `/users/me` → 401 + `JWT401` (회귀 방지)


## 자동 수집되는 메트릭

- `http_server_requests_seconds_*` — 엔드포인트별 p50/p95/p99 latency
- `jvm_memory_used_bytes`, `jvm_gc_*` — JVM 상태
- `hikaricp_connections_*`, `jdbc_connections_*` — DB 커넥션
- `tomcat_threads_*` — 웹 서버
- `logback_events_total` — 로그 레벨별 카운트
- `process_cpu_usage`, `process_uptime_seconds` — 프로세스



## 검증

```
./gradlew :common:test :api:test :app:test
→ BUILD SUCCESSFUL, 45 tests passed (기존 43 + 신규 2)
```


## 🔗 관련 이슈

closes #40