### PR TITLE
[TEST] MockMvc 기반 엔드포인트 통합 테스트 Phase 2 — 전체 도메인 (#44)

### DIFF
--- a/app/src/test/java/com/mediforme/mediforme/AdminIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/AdminIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Admin 엔드포인트 역할 기반 인가 통합 테스트
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AdminIntegrationTest {
+
+    private static final String ADMIN_LOGIN_ID = "integ-admin@test.com";
+    private static final String USER_LOGIN_ID = "integ-user@test.com";
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    private Long adminUserId;
+    private String adminToken;
+    private String userToken;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        User admin = userRepository.save(User.builder()
+            .userLoginId(ADMIN_LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("관리자")
+            .phone("01066666666")
+            .roleCd(1002L).consentCd(1L).statusCd(2001L)  // ADMIN
+            .build());
+        adminUserId = admin.getUserId();
+        adminToken = jwtTokenProvider.createAccessToken(admin.getUserId(), ADMIN_LOGIN_ID, 1002L);
+
+        User regular = userRepository.save(User.builder()
+            .userLoginId(USER_LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("일반")
+            .phone("01077777777")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)  // USER
+            .build());
+        userToken = jwtTokenProvider.createAccessToken(regular.getUserId(), USER_LOGIN_ID, 1001L);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("GET /admin/users/{id} ADMIN 토큰 → 200")
+    void adminEndpoint_withAdminToken_returns200() throws Exception {
+        mvc.perform(get("/admin/users/" + adminUserId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /admin/users/{id} USER 토큰 → 403 ACTION403")
+    void adminEndpoint_withUserToken_returns403() throws Exception {
+        mvc.perform(get("/admin/users/" + adminUserId)
+                .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("ACTION403"));
+    }
+
+    @Test
+    @DisplayName("GET /admin/users/{id} 토큰 없음 → 401 JWT401")
+    void adminEndpoint_noToken_returns401() throws Exception {
+        mvc.perform(get("/admin/users/" + adminUserId))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("JWT401"));
+    }
+}

--- a/app/src/test/java/com/mediforme/mediforme/AuthLogoutReissueIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/AuthLogoutReissueIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.mediforme.mediforme;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.entity.UserToken;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 로그아웃 + 토큰 재발급 통합 테스트
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthLogoutReissueIntegrationTest {
+
+    private static final String ACTIVE_LOGIN_ID = "integ-logout@test.com";
+    private static final String RESIGNED_LOGIN_ID = "integ-logout-resigned@test.com";
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+    @Autowired private ObjectMapper objectMapper;
+
+    private User activeUser;
+    private User resignedUser;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        activeUser = userRepository.save(User.builder()
+            .userLoginId(ACTIVE_LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("활성")
+            .phone("01011111111")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)
+            .build());
+
+        resignedUser = userRepository.save(User.builder()
+            .userLoginId(RESIGNED_LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("탈퇴")
+            .phone("01022222222")
+            .roleCd(1001L).consentCd(1L).statusCd(9999L)
+            .build());
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("POST /auth/logout 정상 → 200 + TokenBlacklistService.addToBlacklist 호출")
+    void logout_valid_blacklistsToken() throws Exception {
+        String accessToken = jwtTokenProvider.createAccessToken(activeUser.getUserId(), ACTIVE_LOGIN_ID, 1001L);
+
+        mvc.perform(post("/auth/logout").header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+
+        verify(tokenBlacklistService).addToBlacklist(accessToken);
+    }
+
+    @Test
+    @DisplayName("POST /auth/logout 토큰 없음 → 401")
+    void logout_noToken_returns401() throws Exception {
+        mvc.perform(post("/auth/logout"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /auth/reissue 유효한 refresh → 200 + 새 accessToken/refreshToken")
+    void reissue_validRefresh_returnsNewTokens() throws Exception {
+        String refreshToken = jwtTokenProvider.createRefreshToken(activeUser.getUserId(), ACTIVE_LOGIN_ID, 1001L);
+        given(userTokenRedisService.findByRefreshToken(refreshToken))
+            .willReturn(Optional.of(UserToken.builder()
+                .refreshToken(refreshToken)
+                .userLoginId(ACTIVE_LOGIN_ID)
+                .userId(activeUser.getUserId())
+                .role("1001")
+                .ttlSeconds(604800L)
+                .build()));
+
+        mvc.perform(post("/auth/reissue").header("Authorization", "Bearer " + refreshToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.result.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.result.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("POST /auth/reissue 저장소에 없는 refresh → 401 JWT401")
+    void reissue_unknownRefresh_returns401() throws Exception {
+        String refreshToken = jwtTokenProvider.createRefreshToken(activeUser.getUserId(), ACTIVE_LOGIN_ID, 1001L);
+        given(userTokenRedisService.findByRefreshToken(refreshToken)).willReturn(Optional.empty());
+
+        mvc.perform(post("/auth/reissue").header("Authorization", "Bearer " + refreshToken))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("JWT401"));
+    }
+
+    @Test
+    @DisplayName("POST /auth/reissue 탈퇴 사용자 refresh → 409 USER_403_001")
+    void reissue_resignedUserRefresh_returns409() throws Exception {
+        String refreshToken = jwtTokenProvider.createRefreshToken(resignedUser.getUserId(), RESIGNED_LOGIN_ID, 1001L);
+        given(userTokenRedisService.findByRefreshToken(refreshToken))
+            .willReturn(Optional.of(UserToken.builder()
+                .refreshToken(refreshToken)
+                .userLoginId(RESIGNED_LOGIN_ID)
+                .userId(resignedUser.getUserId())
+                .role("1001")
+                .ttlSeconds(604800L)
+                .build()));
+
+        mvc.perform(post("/auth/reissue").header("Authorization", "Bearer " + refreshToken))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("USER_403_001"));
+    }
+}

--- a/app/src/test/java/com/mediforme/mediforme/CheckIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/CheckIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 상호작용 Check 도메인 통합 테스트 — PR #37 ApiResponse 래핑 회귀 가드
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CheckIntegrationTest {
+
+    private static final String LOGIN_ID = "integ-check@test.com";
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    private String accessToken;
+    private Long userId;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        User user = userRepository.save(User.builder()
+            .userLoginId(LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("체크")
+            .phone("01055555555")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)
+            .build());
+        userId = user.getUserId();
+        accessToken = jwtTokenProvider.createAccessToken(userId, LOGIN_ID, 1001L);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("POST /v2/medicine-interactions/check → 200 + ApiResponse<List<String>> (PR #37 회귀 가드)")
+    void checkDrugInteractions_returnsApiResponseList() throws Exception {
+        mvc.perform(post("/v2/medicine-interactions/check")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("userId", String.valueOf(userId))
+                .param("newMedication", "아스피린"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"))
+            .andExpect(jsonPath("$.result").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /v2/medicine-interactions/info?medicineName=타이레놀 → 200 + Mock 데이터 ApiResponse 래핑")
+    void info_mockHasData_returnsApiResponseWithData() throws Exception {
+        mvc.perform(get("/v2/medicine-interactions/info")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("medicineName", "타이레놀"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"))
+            .andExpect(jsonPath("$.result[0].name").value("타이레놀"))
+            .andExpect(jsonPath("$.result[0].interactionWarnings").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("GET /v2/medicine-interactions/info?medicineName=없는약 → 200 + 빈 배열 (PR #37 404→200 semantic 유지)")
+    void info_mockNoData_returnsApiResponseEmptyArray() throws Exception {
+        mvc.perform(get("/v2/medicine-interactions/info")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("medicineName", "없는약"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"))
+            .andExpect(jsonPath("$.result").isArray())
+            .andExpect(jsonPath("$.result").isEmpty());
+    }
+}

--- a/app/src/test/java/com/mediforme/mediforme/ResignIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/ResignIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 회원 탈퇴 통합 테스트 — PR #21 정책 실체 검증
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ResignIntegrationTest {
+
+    private static final String LOGIN_ID = "integ-resign@test.com";
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    private User user;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        user = userRepository.save(User.builder()
+            .userLoginId(LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("탈퇴대상")
+            .phone("01033333333")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)
+            .build());
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("DELETE /users/me/resign 정상 → 200 + DB statusCd=9999 + blacklist 추가")
+    void resign_valid_marksResignedAndBlacklists() throws Exception {
+        String accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), LOGIN_ID, 1001L);
+
+        mvc.perform(delete("/users/me/resign").header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+
+        User updated = userRepository.findById(user.getUserId()).orElseThrow();
+        assertThat(updated.getStatusCd()).isEqualTo(9999L);
+
+        verify(tokenBlacklistService).addToBlacklist(accessToken);
+        verify(userTokenRedisService).deleteByUserLoginId(LOGIN_ID);
+    }
+
+    @Test
+    @DisplayName("DELETE /users/me/resign 토큰 없음 → 401 JWT401")
+    void resign_noToken_returns401() throws Exception {
+        mvc.perform(delete("/users/me/resign"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("JWT401"));
+    }
+}

--- a/app/src/test/java/com/mediforme/mediforme/StatusIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/StatusIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.status.domain.Status;
+import com.mediforme.mediforme.status.repository.StatusRepository;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Status CRUD 통합 테스트 + PR #29 DateTimeParseException 회귀 가드
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class StatusIntegrationTest {
+
+    private static final String LOGIN_ID = "integ-status@test.com";
+    private static final LocalDate TEST_DATE = LocalDate.of(2025, 4, 15);
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private StatusRepository statusRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    private User user;
+    private String accessToken;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        user = userRepository.save(User.builder()
+            .userLoginId(LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("상태")
+            .phone("01044444444")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)
+            .build());
+
+        accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), LOGIN_ID, 1001L);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("POST /users/me/statuses 생성 → 200 + ApiResponse")
+    void createStatus_returns200() throws Exception {
+        mvc.perform(post("/users/me/statuses")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"statusDate":"2025-04-15","defaultStatusCd":1,"drinkCd":1,"conditionCd":1,"statusMemo":"컨디션 좋음"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+
+    @Test
+    @DisplayName("GET /users/me/statuses/{date} 조회 → 200 + 해당 날짜 상태")
+    void getStatusByDate_returns200() throws Exception {
+        statusRepository.save(Status.builder()
+            .defaultStatusCd(1L).drinkCd(1L).conditionCd(1L)
+            .statusMemo("시드").statusDate(TEST_DATE).userId(user.getUserId())
+            .build());
+
+        mvc.perform(get("/users/me/statuses/2025-04-15")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+
+    @Test
+    @DisplayName("GET /users/me/statuses/week-summary?startDate=잘못된날짜 → 400 COMMON400 (PR #29 회귀 가드)")
+    void weekSummary_badDate_returns400() throws Exception {
+        mvc.perform(get("/users/me/statuses/week-summary")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("startDate", "2025-13-45")
+                .param("endDate", "2025-04-22"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("COMMON400"))
+            .andExpect(jsonPath("$.message").value("날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"));
+    }
+
+    @Test
+    @DisplayName("PUT /users/me/statuses/{date} 수정 → 200")
+    void updateStatusByDate_returns200() throws Exception {
+        statusRepository.save(Status.builder()
+            .defaultStatusCd(1L).drinkCd(1L).conditionCd(1L)
+            .statusMemo("old").statusDate(TEST_DATE).userId(user.getUserId())
+            .build());
+
+        mvc.perform(put("/users/me/statuses/2025-04-15")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"statusDate":"2025-04-15","defaultStatusCd":2,"drinkCd":1,"conditionCd":1,"statusMemo":"updated"}
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+
+    @Test
+    @DisplayName("DELETE /users/me/statuses/id/{statusId} 삭제 → 200")
+    void deleteStatusById_returns200() throws Exception {
+        Status saved = statusRepository.save(Status.builder()
+            .defaultStatusCd(1L).drinkCd(1L).conditionCd(1L)
+            .statusMemo("to delete").statusDate(TEST_DATE).userId(user.getUserId())
+            .build());
+
+        mvc.perform(delete("/users/me/statuses/id/" + saved.getStatusId())
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+}

--- a/app/src/test/java/com/mediforme/mediforme/UserMedicineIntegrationTest.java
+++ b/app/src/test/java/com/mediforme/mediforme/UserMedicineIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.mediforme.mediforme;
+
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.mediforme.lib.redis.service.UserTokenRedisService;
+import com.mediforme.mediforme.global.security.TokenBlacklistService;
+import com.mediforme.mediforme.global.security.jwt.JwtTokenProvider;
+import com.mediforme.mediforme.medicine.domain.UserMedicine;
+import com.mediforme.mediforme.medicine.repository.UserMedicineRepository;
+import com.mediforme.mediforme.user.domain.User;
+import com.mediforme.mediforme.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * UserMedicine DB CRUD 엔드포인트 통합 테스트
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserMedicineIntegrationTest {
+
+    private static final String LOGIN_ID = "integ-usermed@test.com";
+
+    @MockBean private ImageAnnotatorClient imageAnnotatorClient;
+    @MockBean private RedisConnectionFactory redisConnectionFactory;
+    @MockBean private TokenBlacklistService tokenBlacklistService;
+    @MockBean private UserTokenRedisService userTokenRedisService;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserMedicineRepository userMedicineRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    private String accessToken;
+    private Long userMedicineId;
+
+    @BeforeEach
+    void seed() {
+        given(tokenBlacklistService.isTokenBlacklisted(anyString())).willReturn(false);
+
+        User user = userRepository.save(User.builder()
+            .userLoginId(LOGIN_ID)
+            .password(passwordEncoder.encode("pw"))
+            .userName("복약")
+            .phone("01088888888")
+            .roleCd(1001L).consentCd(1L).statusCd(2001L)
+            .build());
+        accessToken = jwtTokenProvider.createAccessToken(user.getUserId(), LOGIN_ID, 1001L);
+
+        UserMedicine saved = userMedicineRepository.save(UserMedicine.builder()
+            .userId(user.getUserId())
+            .medicineId(1L)
+            .daysOfWeekCd(1234567L)
+            .dosage("1정")
+            .isAlarm(false)
+            .mealCd(1L)
+            .timeCd(1L)
+            .build());
+        userMedicineId = saved.getUserMedicineId();
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("PUT /v2/user-medicine/{id}/check → 200")
+    void check_valid_returns200() throws Exception {
+        mvc.perform(put("/v2/user-medicine/" + userMedicineId + "/check")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+
+    @Test
+    @DisplayName("PUT /v2/user-medicine/{id}/alarm?isOn=true → 200")
+    void toggleAlarm_valid_returns200() throws Exception {
+        mvc.perform(put("/v2/user-medicine/" + userMedicineId + "/alarm")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("isOn", "true"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("COMMON200"));
+    }
+
+    @Test
+    @DisplayName("PUT /v2/user-medicine/{non-existent}/check → 404 MEDICINE402")
+    void check_nonExistent_returns404() throws Exception {
+        mvc.perform(put("/v2/user-medicine/999999/check")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("MEDICINE402"));
+    }
+}


### PR DESCRIPTION
## 📌 개요

PR #43 (Phase 1 — Auth 로그인 + /users/me) 의 후속. 나머지 핵심 도메인 플로우를 MockMvc 로 한 번에 자동화. 이전 PR 들에서 도입된 정책/핫픽스(PR #21, #29, #37)의 실체 회귀 가드를 HTTP 레벨에서 추가.

## 🧪 추가된 테스트 (신규 21건, 6 클래스)

### 1. `AuthLogoutReissueIntegrationTest` — 5건
- `POST /auth/logout` 정상 → 200 + `TokenBlacklistService.addToBlacklist` 호출 검증
- `POST /auth/logout` 토큰 없음 → 401
- `POST /auth/reissue` 유효한 refresh (Redis 에 저장된) → 200 + 새 토큰 쌍
- `POST /auth/reissue` 저장소에 없는 refresh → 401 `JWT401`
- `POST /auth/reissue` 탈퇴 사용자 refresh → 409 `USER_403_001`

### 2. `ResignIntegrationTest` — 2건 (PR #21 정책 실체)
- `DELETE /users/me/resign` 정상 → 200 + DB `statusCd=9999` 반영 + blacklist/Redis 삭제 호출 검증
- `DELETE /users/me/resign` 토큰 없음 → 401 `JWT401`

### 3. `StatusIntegrationTest` — 5건 (PR #29 회귀 가드)
- `POST /users/me/statuses` 생성 → 200
- `GET /users/me/statuses/{date}` → 200
- `GET /users/me/statuses/week-summary?startDate=2025-13-45&endDate=...` → **400 `COMMON400` + "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"**
- `PUT /users/me/statuses/{date}` → 200
- `DELETE /users/me/statuses/id/{id}` → 200

### 4. `CheckIntegrationTest` — 3건 (PR #37 회귀 가드)
- `POST /v2/medicine-interactions/check` → 200 + `ApiResponse<List<String>>`
- `GET /v2/medicine-interactions/info?medicineName=타이레놀` → 200 + ApiResponse + Mock 데이터
- `GET /v2/medicine-interactions/info?medicineName=없는약` → 200 + 빈 배열 (PR #37 404→200 semantic 유지)

### 5. `AdminIntegrationTest` — 3건
- `GET /admin/users/{id}` ADMIN 토큰 → 200
- `GET /admin/users/{id}` USER 토큰 → 403 `ACTION403`
- `GET /admin/users/{id}` 토큰 없음 → 401 `JWT401`

### 6. `UserMedicineIntegrationTest` — 3건
- `PUT /v2/user-medicine/{id}/check` → 200
- `PUT /v2/user-medicine/{id}/alarm?isOn=true` → 200
- `PUT /v2/user-medicine/{non-existent}/check` → 404 `MEDICINE402`

## 🛠️ 공통 인프라

```
@SpringBootTest + @AutoConfigureMockMvc + @ActiveProfiles("test") + @Transactional
```

- H2 메모리 DB + 테스트별 트랜잭션 롤백
- `@BeforeEach` 에서 `UserRepository.save`, `UserMedicineRepository.save`, `StatusRepository.save` 로 필요한 시드 주입
- 토큰은 `JwtTokenProvider` 로 직접 발급 (login HTTP 거치지 않음)
- `@MockBean`: `ImageAnnotatorClient`, `RedisConnectionFactory`, `TokenBlacklistService`, `UserTokenRedisService`

## 📊 누적 테스트 현황

| 단계 | 테스트 수 |
|---|---:|
| 리팩터 이전 | 0 |
| PR #27 | 1 |
| PR #31 | +14 |
| PR #33 | +24 |
| PR #35 | +2 |
| PR #37 | +2 |
| PR #41 | +2 |
| PR #43 (Phase 1) | +7 |
| **이 PR (Phase 2)** | **+21** |
| **합계** | **73** |

## 스코프 밖 (별도 PR)

- 회원가입 (SMS 인증 의존)
- 온보딩 플로우
- Medicine Search/Info (MFDS 실호출 mock 설계 필요)
- Medicine Recognition (multipart + Vision 실호출)
- Chatbot (OpenAI 외부 의존)

## 검증

```
./gradlew :common:test :api:test :app:test
→ BUILD SUCCESSFUL, 73 tests passed
```

## 🔗 관련 이슈

closes #44