### PR TITLE
refactor: 검색 어댑터 다중화 + 퍼지 매칭 + OcrPort 추출 (Phase A 1단계)

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/medicine/dto/MedicineSearchItemDto.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/dto/MedicineSearchItemDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class MedicineSearchItemDto {
     private String name;        // item name
     private String imageUrl;    // item image
+    private String source;      // MFDS / FDA / RxNorm
 }

--- a/api/src/main/java/com/mediforme/mediforme/medicine/external/adapter/GoogleVisionOcrAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/external/adapter/GoogleVisionOcrAdapter.java
@@ -1,0 +1,57 @@
+package com.mediforme.mediforme.medicine.external.adapter;
+
+import com.google.cloud.vision.v1.AnnotateImageRequest;
+import com.google.cloud.vision.v1.AnnotateImageResponse;
+import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
+import com.google.cloud.vision.v1.Feature;
+import com.google.cloud.vision.v1.Image;
+import com.google.cloud.vision.v1.ImageAnnotatorClient;
+import com.google.protobuf.ByteString;
+import com.mediforme.mediforme.medicine.external.port.OcrPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * GCP Vision 기반 OCR 어댑터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleVisionOcrAdapter implements OcrPort {
+
+    private final ImageAnnotatorClient imageAnnotatorClient;
+
+    @Override
+    public String extractText(byte[] image) {
+        if (image == null || image.length == 0) return null;
+
+        try {
+            ByteString imgBytes = ByteString.copyFrom(image);
+            Image img = Image.newBuilder().setContent(imgBytes).build();
+
+            AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+                .addFeatures(Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build())
+                .setImage(img)
+                .build();
+
+            BatchAnnotateImagesResponse batch =
+                imageAnnotatorClient.batchAnnotateImages(List.of(request));
+            AnnotateImageResponse response = batch.getResponsesList().get(0);
+
+            if (response.hasError()) {
+                log.warn("GCP Vision error: {}", response.getError().getMessage());
+                return null;
+            }
+            if (response.getTextAnnotationsList().isEmpty()) return null;
+
+            return response.getTextAnnotationsList().get(0).getDescription();
+
+        } catch (Exception e) {
+            log.warn("Vision OCR failed", e);
+            return null;
+        }
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/medicine/external/client/FdaDrugLabelClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/external/client/FdaDrugLabelClient.java
@@ -1,0 +1,81 @@
+package com.mediforme.mediforme.medicine.external.client;
+
+import com.mediforme.mediforme.medicine.external.FdaApiConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * openFDA drug label API 클라이언트
+ */
+@Slf4j
+@Component
+public class FdaDrugLabelClient {
+
+    private static final int DEFAULT_LIMIT = 10;
+
+    private final RestClient restClient;
+
+    public FdaDrugLabelClient(FdaApiConfig config) {
+        this.restClient = RestClient.builder()
+            .baseUrl(config.getBaseUrl())
+            .build();
+    }
+
+    /**
+     * 이름(브랜드/제네릭)으로 검색하여 각 결과의 openfda 섹션을 리스트로 반환
+     */
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> fetchOpenFdaByName(String name) {
+        if (name == null || name.isBlank()) return Collections.emptyList();
+
+        String safe = sanitize(name);
+        if (safe.isBlank()) return Collections.emptyList();
+
+        String search = "openfda.brand_name:\"" + safe + "\""
+            + " OR openfda.generic_name:\"" + safe + "\"";
+
+        try {
+            Map<String, Object> response = restClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/drug/label.json")
+                    .queryParam("search", search)
+                    .queryParam("limit", DEFAULT_LIMIT)
+                    .build())
+                .retrieve()
+                .body(Map.class);
+
+            if (response == null) return Collections.emptyList();
+            Object results = response.get("results");
+            if (!(results instanceof List<?> list)) return Collections.emptyList();
+
+            List<Map<String, Object>> out = new ArrayList<>();
+            for (Object r : list) {
+                if (r instanceof Map<?, ?> m) {
+                    Object openfda = m.get("openfda");
+                    if (openfda instanceof Map<?, ?> o) {
+                        out.add((Map<String, Object>) o);
+                    }
+                }
+            }
+            return out;
+
+        } catch (HttpClientErrorException.NotFound e) {
+            // openFDA: 매칭 없음 = 404
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Lucene 쿼리 인젝션 방지용 최소 sanitization
+     * 영문·숫자·한글·공백만 허용
+     */
+    private String sanitize(String name) {
+        return name.replaceAll("[^a-zA-Z0-9가-힣 ]", "").trim();
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/medicine/external/client/RxNormClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/external/client/RxNormClient.java
@@ -1,0 +1,67 @@
+package com.mediforme.mediforme.medicine.external.client;
+
+import com.mediforme.mediforme.medicine.external.RxNormApiConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * NIH RxNorm REST API 클라이언트
+ * - 엔드포인트: /approximateTerm.json
+ * - 퍼지 매칭 기반 후보 이름 제안 (OCR 오타 복원용)
+ */
+@Slf4j
+@Component
+public class RxNormClient {
+
+    private static final int DEFAULT_MAX_ENTRIES = 10;
+
+    private final RestClient restClient;
+
+    public RxNormClient(RxNormApiConfig config) {
+        this.restClient = RestClient.builder()
+            .baseUrl(config.getBaseUrl())
+            .build();
+    }
+
+    /**
+     * 입력 이름 기반 후보 리스트 반환 (유사도 내림차순은 RxNorm 측에서 보장)
+     */
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> fetchApproximateCandidates(String term) {
+        if (term == null || term.isBlank()) return Collections.emptyList();
+
+        try {
+            Map<String, Object> response = restClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/approximateTerm.json")
+                    .queryParam("term", term)
+                    .queryParam("maxEntries", DEFAULT_MAX_ENTRIES)
+                    .build())
+                .retrieve()
+                .body(Map.class);
+
+            if (response == null) return Collections.emptyList();
+            Object group = response.get("approximateGroup");
+            if (!(group instanceof Map<?, ?> g)) return Collections.emptyList();
+
+            Object candidates = g.get("candidate");
+            if (!(candidates instanceof List<?> list)) return Collections.emptyList();
+
+            List<Map<String, Object>> out = new ArrayList<>();
+            for (Object c : list) {
+                if (c instanceof Map<?, ?> m) {
+                    out.add((Map<String, Object>) m);
+                }
+            }
+            return out;
+        } catch (Exception e) {
+            log.warn("RxNorm approximateTerm call failed. term={}", term, e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/medicine/external/port/OcrPort.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/external/port/OcrPort.java
@@ -1,0 +1,13 @@
+package com.mediforme.mediforme.medicine.external.port;
+
+/**
+ * 이미지 OCR 포트
+ */
+public interface OcrPort {
+
+    /**
+     * 이미지 바이트에서 raw 텍스트 추출
+     * 실패/빈 이미지는 null 반환
+     */
+    String extractText(byte[] image);
+}

--- a/api/src/main/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImpl.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImpl.java
@@ -1,8 +1,7 @@
 package com.mediforme.mediforme.medicine.service.impl;
 
-import com.google.cloud.vision.v1.*;
-import com.google.protobuf.ByteString;
 import com.mediforme.mediforme.medicine.dto.MedicineRecognitionResultDto;
+import com.mediforme.mediforme.medicine.external.port.OcrPort;
 import com.mediforme.mediforme.medicine.service.MedicineImageRecognitionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,21 +10,24 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.text.Normalizer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MedicineImageRecognitionServiceImpl  implements MedicineImageRecognitionService {
+public class MedicineImageRecognitionServiceImpl implements MedicineImageRecognitionService {
 
-    // client는 Bean으로 주입 받아 재사용
-    private final ImageAnnotatorClient imageAnnotatorClient;
+    private final OcrPort ocrPort;
 
     // 후보 최대 개수 (외부 API 호출 폭증 방지)
     private static final int MAX_CANDIDATES = 5;
-
 
     // 약봉투/약통/처방전에서 흔히 나오는 불필요 단어(후보 제거)
     private static final Set<String> STOPWORDS = Set.of(
@@ -42,15 +44,11 @@ public class MedicineImageRecognitionServiceImpl  implements MedicineImageRecogn
     private static final Pattern PAREN_PATTERN =
         Pattern.compile("\\([^)]*\\)");
 
-
     /**
      * 가장 유력한 후보 1개만 반환
-     * @param imageFile
-     * @return
      */
     @Override
     public String recognizeMedicineName(MultipartFile imageFile) {
-        // 후보 중 1순위만 반환
         MedicineRecognitionResultDto result = recognizeMedicineCandidates(imageFile);
         if (result == null || result.getCandidates() == null || result.getCandidates().isEmpty()) {
             return null;
@@ -59,73 +57,34 @@ public class MedicineImageRecognitionServiceImpl  implements MedicineImageRecogn
     }
 
     /**
-     * 후보 여러 개인 경우, OCR 전체 텍스트 반환
-     * @param imageFile
-     * @return
+     * OCR 후 후보 여러 개 + fullText 반환
      */
     @Override
     public MedicineRecognitionResultDto recognizeMedicineCandidates(MultipartFile imageFile) {
         if (imageFile == null || imageFile.isEmpty()) {
-            return MedicineRecognitionResultDto.builder()
-                .fullText(null)
-                .candidates(Collections.emptyList())
-                .build();
+            return empty();
         }
 
         try {
-            ByteString imgBytes = ByteString.copyFrom(imageFile.getBytes());
-            Image img = Image.newBuilder().setContent(imgBytes).build();
-
-            // TEXT_DETECTION을 우선 적용
-            List<Feature> features = List.of(
-                Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build()
-            );
-
-            AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
-                .addAllFeatures(features)
-                .setImage(img)
-                .build();
-
-            BatchAnnotateImagesResponse batch = imageAnnotatorClient.batchAnnotateImages(List.of(request));
-            AnnotateImageResponse response = batch.getResponsesList().get(0);
-
-            if (response.hasError()) {
-                log.warn("GCP Vision error: {}", response.getError().getMessage());
-                return MedicineRecognitionResultDto.builder()
-                    .fullText(null)
-                    .candidates(Collections.emptyList())
-                    .build();
-            }
-
-            String fullText = extractFullText(response);
-            List<String> candidates = extractCandidates(fullText);
+            String fullText = ocrPort.extractText(imageFile.getBytes());
+            if (fullText == null || fullText.isBlank()) return empty();
 
             return MedicineRecognitionResultDto.builder()
                 .fullText(fullText)
-                .candidates(candidates)
+                .candidates(extractCandidates(fullText))
                 .build();
 
         } catch (IOException e) {
-            log.warn("Vision image read failed", e);
-            return MedicineRecognitionResultDto.builder()
-                .fullText(null)
-                .candidates(Collections.emptyList())
-                .build();
-        } catch (Exception e) {
-            log.warn("Vision recognition failed", e);
-            return MedicineRecognitionResultDto.builder()
-                .fullText(null)
-                .candidates(Collections.emptyList())
-                .build();
+            log.warn("Image read failed", e);
+            return empty();
         }
     }
 
-    private String extractFullText(AnnotateImageResponse response) {
-        if (response.getTextAnnotationsList() == null || response.getTextAnnotationsList().isEmpty()) {
-            return null;
-        }
-        // 보통 첫 번째 element가 전체 텍스트를 담는 케이스가 많음
-        return response.getTextAnnotationsList().get(0).getDescription();
+    private MedicineRecognitionResultDto empty() {
+        return MedicineRecognitionResultDto.builder()
+            .fullText(null)
+            .candidates(Collections.emptyList())
+            .build();
     }
 
     /**
@@ -137,22 +96,20 @@ public class MedicineImageRecognitionServiceImpl  implements MedicineImageRecogn
         if (fullText == null || fullText.isBlank()) return Collections.emptyList();
 
         String normalized = Normalizer.normalize(fullText, Normalizer.Form.NFKC);
-
         List<String> raw = new ArrayList<>();
 
-        // 1) 라인 단위(약 이름이 한 줄로 적히는 경우 많음)
+        // 1) 라인 단위
         for (String line : normalized.split("\\R")) {
             String cleaned = clean(line);
             if (isCandidate(cleaned)) raw.add(cleaned);
         }
 
-        // 2) 토큰 단위(분절된 경우)
+        // 2) 토큰 단위
         for (String token : normalized.split("[\\s,;:/\\\\|]+")) {
             String cleaned = clean(token);
             if (isCandidate(cleaned)) raw.add(cleaned);
         }
 
-        // 중복 제거 및 스코어링 정렬
         Map<String, Integer> scored = new HashMap<>();
         for (String t : raw) {
             scored.put(t, Math.max(scored.getOrDefault(t, 0), score(t)));
@@ -168,63 +125,41 @@ public class MedicineImageRecognitionServiceImpl  implements MedicineImageRecogn
 
     private String clean(String token) {
         if (token == null) return null;
-
         String t = token.trim();
         if (t.isBlank()) return t;
 
-        // 괄호 제거(성분명/부가정보가 붙는 경우)
         t = PAREN_PATTERN.matcher(t).replaceAll("").trim();
-
-        // 용량 제거
         t = DOSAGE_PATTERN.matcher(t).replaceAll("").trim();
-
-        // 불필요 기호 제거
         t = t.replaceAll("[\\[\\]{}<>\"'`~!@#$%^&*_+=?]", "").trim();
 
-        // 너무 긴 문장은 후보로 부적합(폭발 방지)
         if (t.length() > 40) t = t.substring(0, 40);
-
         return t;
     }
 
     private boolean isCandidate(String token) {
         if (token == null) return false;
-
         String t = token.trim();
         if (t.isBlank()) return false;
         if (t.length() < 2) return false;
-
-        // 숫자만 제거
         if (t.matches("\\d+")) return false;
-
-        // 한글/영문이 있어야 함
         if (!t.matches(".*[가-힣A-Za-z].*")) return false;
-
-        // 불필요 단어 제거(완전 일치만)
         if (STOPWORDS.contains(t)) return false;
-
         return true;
     }
 
     /**
-     * 간단 스코어링:
-     * - 약품명 suffix(정/캡슐/서방정 등) 포함 시 가산
-     * - 한글 포함 가산
+     * 간단 스코어링: 약품명 suffix + 한글 포함 가산
      */
     private int score(String token) {
         if (token == null) return 0;
-
         int s = 0;
         if (token.matches(".*[가-힣].*")) s += 2;
-
         if (token.endsWith("정")) s += 3;
         if (token.contains("서방")) s += 2;
         if (token.contains("캡슐")) s += 2;
         if (token.contains("현탁")) s += 2;
         if (token.contains("시럽")) s += 2;
-
-        if (token.length() > 25) s -= 1; // 너무 길면 약 이름이 아닐 확률 증가
-
+        if (token.length() > 25) s -= 1;
         return s;
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
@@ -1,0 +1,22 @@
+package com.mediforme.mediforme.search.adapter;
+
+import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * openFDA drug label 어댑터
+ */
+@Slf4j
+@Component
+public class FdaMedicineSearchAdapter implements MedicineSearchPort {
+
+    @Override
+    public List<MedicineSearchItemDto> searchByName(String itemName) {
+        return Collections.emptyList();
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
@@ -1,22 +1,64 @@
 package com.mediforme.mediforme.search.adapter;
 
 import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.medicine.external.client.FdaDrugLabelClient;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
- * openFDA drug label 어댑터
+ * openFDA drug label 기반 어댑터
+ * - brand_name, 없으면 generic_name 우선순위로 이름 매핑
+ * - imageUrl 은 openFDA 미제공으로 null
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class FdaMedicineSearchAdapter implements MedicineSearchPort {
+
+    private static final String SOURCE = "FDA";
+
+    private final FdaDrugLabelClient client;
 
     @Override
     public List<MedicineSearchItemDto> searchByName(String itemName) {
-        return Collections.emptyList();
+        try {
+            List<Map<String, Object>> openfdas = client.fetchOpenFdaByName(itemName);
+            if (openfdas.isEmpty()) return Collections.emptyList();
+
+            List<MedicineSearchItemDto> list = new ArrayList<>();
+            for (Map<String, Object> openfda : openfdas) {
+                String name = firstElement(openfda, "brand_name");
+                if (name == null) name = firstElement(openfda, "generic_name");
+                if (name == null || name.isBlank()) continue;
+
+                list.add(MedicineSearchItemDto.builder()
+                    .name(name)
+                    .imageUrl(null)
+                    .source(SOURCE)
+                    .build());
+            }
+            return list;
+
+        } catch (Exception e) {
+            log.warn("FDA search failed. itemName={}", itemName, e);
+            return Collections.emptyList();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String firstElement(Map<String, Object> map, String key) {
+        Object v = map.get(key);
+        if (v instanceof List<?> l && !l.isEmpty()) {
+            Object first = l.get(0);
+            return first == null ? null : String.valueOf(first).trim();
+        }
+        return null;
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/MfdsMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/MfdsMedicineSearchAdapter.java
@@ -1,7 +1,5 @@
 package com.mediforme.mediforme.search.adapter;
 
-import com.mediforme.common.exception.CustomApiException;
-import com.mediforme.common.exception.ErrorCode;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
 import com.mediforme.mediforme.medicine.external.client.MfdsMedicineClient;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
@@ -9,10 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.json.simple.parser.ParseException;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +21,8 @@ import static com.mediforme.mediforme.medicine.external.client.MfdsMedicineClien
 @Component
 @RequiredArgsConstructor
 public class MfdsMedicineSearchAdapter implements MedicineSearchPort {
+
+    private static final String SOURCE = "MFDS";
 
     private final MfdsMedicineClient mfdsClient;
 
@@ -48,13 +46,15 @@ public class MfdsMedicineSearchAdapter implements MedicineSearchPort {
                         getString(item, "itemImage"),
                         getString(item, "ITEM_IMAGE"),
                         "이미지 없음"))
+                    .source(SOURCE)
                     .build());
             }
             return list;
 
-        } catch (IOException | ParseException e) {
+        } catch (Exception e) {
+            // 병렬 호출 실패 격리 - 다른 어댑터 결과는 살림
             log.warn("MFDS search failed. itemName={}", itemName, e);
-            throw new CustomApiException(ErrorCode.INTERNAL_SERVER_ERROR, e);
+            return Collections.emptyList();
         }
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
@@ -1,22 +1,65 @@
 package com.mediforme.mediforme.search.adapter;
 
 import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.medicine.external.client.RxNormClient;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
- * NIH RxNorm 어댑터
+ * RxNorm approximateTerm 기반 어댑터
+ * - OCR 오타 복원 용도 — 이름 후보만 제공 (imageUrl 없음)
+ * - 동일 rxcui 중복 제거
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class RxNormMedicineSearchAdapter implements MedicineSearchPort {
+
+    private static final String SOURCE = "RxNorm";
+
+    private final RxNormClient client;
 
     @Override
     public List<MedicineSearchItemDto> searchByName(String itemName) {
-        return Collections.emptyList();
+        try {
+            List<Map<String, Object>> candidates = client.fetchApproximateCandidates(itemName);
+            if (candidates.isEmpty()) return Collections.emptyList();
+
+            Set<String> seen = new LinkedHashSet<>();
+            List<MedicineSearchItemDto> list = new ArrayList<>();
+
+            for (Map<String, Object> c : candidates) {
+                String name = stringValue(c.get("name"));
+                if (name == null || name.isBlank()) continue;
+
+                String rxcui = stringValue(c.get("rxcui"));
+                String dedupKey = rxcui != null ? rxcui : name;
+                if (!seen.add(dedupKey)) continue;
+
+                list.add(MedicineSearchItemDto.builder()
+                    .name(name)
+                    .imageUrl(null)
+                    .source(SOURCE)
+                    .build());
+            }
+            return list;
+
+        } catch (Exception e) {
+            log.warn("RxNorm search failed. itemName={}", itemName, e);
+            return Collections.emptyList();
+        }
+    }
+
+    private String stringValue(Object v) {
+        return v == null ? null : String.valueOf(v).trim();
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
@@ -1,0 +1,22 @@
+package com.mediforme.mediforme.search.adapter;
+
+import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * NIH RxNorm 어댑터
+ */
+@Slf4j
+@Component
+public class RxNormMedicineSearchAdapter implements MedicineSearchPort {
+
+    @Override
+    public List<MedicineSearchItemDto> searchByName(String itemName) {
+        return Collections.emptyList();
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/search/application/MedicineSearchService.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/application/MedicineSearchService.java
@@ -3,24 +3,87 @@ package com.mediforme.mediforme.search.application;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchResponseDto;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
-import lombok.RequiredArgsConstructor;
+import com.mediforme.mediforme.search.support.JaroWinklerSimilarity;
+import com.mediforme.mediforme.search.support.TextNormalizer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 약 검색 유스케이스
+ * - 여러 MedicineSearchPort를 병렬 호출 후 결과 병합
+ * - 정규화된 이름 기준 중복 제거, 쿼리 유사도 내림차순 정렬
+ * - 개별 어댑터 실패/타임아웃은 격리
  */
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class MedicineSearchService {
 
-    private final MedicineSearchPort medicineSearchPort;
+    private static final long TIMEOUT_MS = 2000;
+
+    private final List<MedicineSearchPort> ports;
+    private final JaroWinklerSimilarity similarity;
+    private final Executor executor;
+
+    public MedicineSearchService(List<MedicineSearchPort> ports,
+                                 JaroWinklerSimilarity similarity,
+                                 @Qualifier("searchExecutor") Executor executor) {
+        this.ports = ports;
+        this.similarity = similarity;
+        this.executor = executor;
+    }
 
     public MedicineSearchResponseDto searchByName(String name) {
-        List<MedicineSearchItemDto> medicines = medicineSearchPort.searchByName(name);
-        return MedicineSearchResponseDto.builder()
-            .medicines(medicines)
-            .build();
+        String normalizedQuery = TextNormalizer.normalize(name);
+
+        List<CompletableFuture<List<MedicineSearchItemDto>>> futures = ports.stream()
+            .map(port -> CompletableFuture
+                .supplyAsync(() -> safeSearch(port, name), executor)
+                .orTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .exceptionally(ex -> {
+                    log.warn("adapter {} timed out or failed: {}",
+                        port.getClass().getSimpleName(), ex.getMessage());
+                    return Collections.emptyList();
+                }))
+            .toList();
+
+        Map<String, Scored> best = new LinkedHashMap<>();
+        for (CompletableFuture<List<MedicineSearchItemDto>> f : futures) {
+            for (MedicineSearchItemDto item : f.join()) {
+                String key = TextNormalizer.normalize(item.getName());
+                if (key.isEmpty()) continue;
+                double score = similarity.score(normalizedQuery, key);
+                best.merge(key, new Scored(item, score),
+                    (a, b) -> a.score >= b.score ? a : b);
+            }
+        }
+
+        List<MedicineSearchItemDto> merged = best.values().stream()
+            .sorted(Comparator.comparingDouble((Scored s) -> s.score).reversed())
+            .map(s -> s.item)
+            .toList();
+
+        return MedicineSearchResponseDto.builder().medicines(merged).build();
     }
+
+    private List<MedicineSearchItemDto> safeSearch(MedicineSearchPort port, String name) {
+        try {
+            List<MedicineSearchItemDto> r = port.searchByName(name);
+            return r != null ? r : Collections.emptyList();
+        } catch (Exception e) {
+            log.warn("adapter {} threw: {}", port.getClass().getSimpleName(), e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    private record Scored(MedicineSearchItemDto item, double score) {}
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/config/SearchExecutorConfig.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/config/SearchExecutorConfig.java
@@ -1,0 +1,23 @@
+package com.mediforme.mediforme.search.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 검색 어댑터 병렬 호출용 Executor
+ */
+@Configuration
+public class SearchExecutorConfig {
+
+    @Bean(name = "searchExecutor", destroyMethod = "shutdown")
+    public ExecutorService searchExecutor() {
+        return Executors.newFixedThreadPool(6, r -> {
+            Thread t = new Thread(r, "search-adapter");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/search/support/JaroWinklerSimilarity.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/support/JaroWinklerSimilarity.java
@@ -1,0 +1,66 @@
+package com.mediforme.mediforme.search.support;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Jaro-Winkler 유사도 (0.0~1.0)
+ * 공통 접두사에 가산점 — 약 이름 OCR 오타 매칭에 사용
+ */
+@Component
+public class JaroWinklerSimilarity {
+
+    private static final double PREFIX_SCALE = 0.1;
+    private static final int MAX_PREFIX = 4;
+
+    public double score(String s1, String s2) {
+        if (s1 == null || s2 == null) return 0.0;
+        if (s1.equals(s2)) return 1.0;
+        if (s1.isEmpty() || s2.isEmpty()) return 0.0;
+
+        double jaro = jaro(s1, s2);
+        if (jaro == 0.0) return 0.0;
+
+        int prefix = 0;
+        int max = Math.min(MAX_PREFIX, Math.min(s1.length(), s2.length()));
+        for (int i = 0; i < max; i++) {
+            if (s1.charAt(i) == s2.charAt(i)) prefix++;
+            else break;
+        }
+        return jaro + prefix * PREFIX_SCALE * (1 - jaro);
+    }
+
+    private double jaro(String s1, String s2) {
+        int matchDistance = Math.max(s1.length(), s2.length()) / 2 - 1;
+        if (matchDistance < 0) matchDistance = 0;
+
+        boolean[] s1Matches = new boolean[s1.length()];
+        boolean[] s2Matches = new boolean[s2.length()];
+        int matches = 0;
+
+        for (int i = 0; i < s1.length(); i++) {
+            int start = Math.max(0, i - matchDistance);
+            int end = Math.min(i + matchDistance + 1, s2.length());
+            for (int j = start; j < end; j++) {
+                if (s2Matches[j]) continue;
+                if (s1.charAt(i) != s2.charAt(j)) continue;
+                s1Matches[i] = true;
+                s2Matches[j] = true;
+                matches++;
+                break;
+            }
+        }
+        if (matches == 0) return 0.0;
+
+        int transpositions = 0;
+        int k = 0;
+        for (int i = 0; i < s1.length(); i++) {
+            if (!s1Matches[i]) continue;
+            while (!s2Matches[k]) k++;
+            if (s1.charAt(i) != s2.charAt(k)) transpositions++;
+            k++;
+        }
+
+        double m = matches;
+        return (m / s1.length() + m / s2.length() + (m - transpositions / 2.0) / m) / 3.0;
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/search/support/TextNormalizer.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/support/TextNormalizer.java
@@ -1,0 +1,31 @@
+package com.mediforme.mediforme.search.support;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+/**
+ * 약 이름 정규화 유틸
+ */
+public final class TextNormalizer {
+
+    private static final Pattern PAREN = Pattern.compile("\\([^)]*\\)");
+    private static final Pattern DOSAGE = Pattern.compile(
+        "(?i)\\d+(?:\\.\\d+)?\\s*(?:mg|g|ml|mcg|ug|밀리그램|그램|밀리리터)"
+    );
+    private static final Pattern NON_ALNUM_KOR = Pattern.compile("[^가-힣a-z0-9]");
+
+    private TextNormalizer() {}
+
+    /**
+     * 매칭용 정규화. 괄호·용량·공백·대소문자·특수문자 제거
+     */
+    public static String normalize(String raw) {
+        if (raw == null) return "";
+        String t = Normalizer.normalize(raw.trim(), Normalizer.Form.NFKC);
+        t = PAREN.matcher(t).replaceAll("");
+        t = DOSAGE.matcher(t).replaceAll("");
+        t = t.toLowerCase();
+        t = NON_ALNUM_KOR.matcher(t).replaceAll("");
+        return t;
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapterTest.java
@@ -1,0 +1,86 @@
+package com.mediforme.mediforme.search.adapter;
+
+import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.medicine.external.client.FdaDrugLabelClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class FdaMedicineSearchAdapterTest {
+
+    @Mock private FdaDrugLabelClient client;
+
+    @InjectMocks private FdaMedicineSearchAdapter adapter;
+
+    @Test
+    @DisplayName("brand_name 우선으로 DTO 매핑, source=FDA")
+    void brandNamePriority() {
+        given(client.fetchOpenFdaByName("tylenol")).willReturn(List.of(
+            Map.of(
+                "brand_name", List.of("TYLENOL"),
+                "generic_name", List.of("ACETAMINOPHEN")
+            )
+        ));
+
+        List<MedicineSearchItemDto> result = adapter.searchByName("tylenol");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("TYLENOL");
+        assertThat(result.get(0).getSource()).isEqualTo("FDA");
+        assertThat(result.get(0).getImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("brand_name 없으면 generic_name 으로 fallback")
+    void fallbackToGenericName() {
+        given(client.fetchOpenFdaByName("acetaminophen")).willReturn(List.of(
+            Map.of("generic_name", List.of("ACETAMINOPHEN"))
+        ));
+
+        List<MedicineSearchItemDto> result = adapter.searchByName("acetaminophen");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("ACETAMINOPHEN");
+    }
+
+    @Test
+    @DisplayName("이름이 하나도 없는 결과는 스킵")
+    void skipEntriesWithoutName() {
+        given(client.fetchOpenFdaByName("unknown")).willReturn(List.of(
+            Map.of("manufacturer_name", List.of("ACME"))
+        ));
+
+        List<MedicineSearchItemDto> result = adapter.searchByName("unknown");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("클라이언트가 빈 리스트 반환하면 빈 결과")
+    void clientReturnsEmpty() {
+        given(client.fetchOpenFdaByName("없는약")).willReturn(Collections.emptyList());
+
+        assertThat(adapter.searchByName("없는약")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("클라이언트 예외 시 빈 리스트로 격리")
+    void clientThrows_returnsEmpty() {
+        given(client.fetchOpenFdaByName(anyString()))
+            .willThrow(new RuntimeException("network down"));
+
+        assertThat(adapter.searchByName("tylenol")).isEmpty();
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapterTest.java
@@ -1,0 +1,83 @@
+package com.mediforme.mediforme.search.adapter;
+
+import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
+import com.mediforme.mediforme.medicine.external.client.RxNormClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RxNormMedicineSearchAdapterTest {
+
+    @Mock private RxNormClient client;
+
+    @InjectMocks private RxNormMedicineSearchAdapter adapter;
+
+    @Test
+    @DisplayName("후보 이름을 DTO 로 매핑, source=RxNorm")
+    void mapCandidates() {
+        given(client.fetchApproximateCandidates("tyenol")).willReturn(List.of(
+            Map.of("rxcui", "202433", "name", "TYLENOL", "score", "82"),
+            Map.of("rxcui", "307696", "name", "Tylenol Extra Strength", "score", "60")
+        ));
+
+        List<MedicineSearchItemDto> result = adapter.searchByName("tyenol");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(MedicineSearchItemDto::getName)
+            .containsExactly("TYLENOL", "Tylenol Extra Strength");
+        assertThat(result).allMatch(i -> "RxNorm".equals(i.getSource()));
+        assertThat(result).allMatch(i -> i.getImageUrl() == null);
+    }
+
+    @Test
+    @DisplayName("같은 rxcui 는 중복 제거")
+    void dedupByRxcui() {
+        given(client.fetchApproximateCandidates("tylenol")).willReturn(List.of(
+            Map.of("rxcui", "202433", "name", "TYLENOL"),
+            Map.of("rxcui", "202433", "name", "TYLENOL")
+        ));
+
+        List<MedicineSearchItemDto> result = adapter.searchByName("tylenol");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이름 없는 후보는 스킵")
+    void skipEntriesWithoutName() {
+        given(client.fetchApproximateCandidates("x")).willReturn(List.of(
+            Map.of("rxcui", "1", "score", "50")
+        ));
+
+        assertThat(adapter.searchByName("x")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("클라이언트 빈 리스트면 빈 결과")
+    void emptyClientResult() {
+        given(client.fetchApproximateCandidates("없는약")).willReturn(Collections.emptyList());
+
+        assertThat(adapter.searchByName("없는약")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("클라이언트 예외도 빈 결과로 격리")
+    void clientThrows_returnsEmpty() {
+        given(client.fetchApproximateCandidates(anyString()))
+            .willThrow(new RuntimeException("network down"));
+
+        assertThat(adapter.searchByName("tylenol")).isEmpty();
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
@@ -3,10 +3,11 @@ package com.mediforme.mediforme.search.application;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchResponseDto;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
+import com.mediforme.mediforme.search.support.JaroWinklerSimilarity;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -14,53 +15,93 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class MedicineSearchServiceTest {
 
-    @Mock
-    private MedicineSearchPort port;
+    @Mock private MedicineSearchPort portA;
+    @Mock private MedicineSearchPort portB;
 
-    @InjectMocks
     private MedicineSearchService service;
 
-    @Test
-    @DisplayName("포트가 빈 리스트 반환 시 빈 응답 DTO 로 래핑")
-    void searchByName_emptyResult_returnsEmptyWrappedResponse() {
-        given(port.searchByName("없는약")).willReturn(Collections.emptyList());
-
-        MedicineSearchResponseDto response = service.searchByName("없는약");
-
-        assertThat(response).isNotNull();
-        assertThat(response.getMedicines()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("포트가 여러 항목 반환 시 순서 유지하여 그대로 래핑")
-    void searchByName_multipleItems_wrapsInOrder() {
-        List<MedicineSearchItemDto> items = List.of(
-            MedicineSearchItemDto.builder().name("타이레놀").imageUrl("url1").build(),
-            MedicineSearchItemDto.builder().name("타이레놀펜").imageUrl("url2").build(),
-            MedicineSearchItemDto.builder().name("타이레놀콜드").imageUrl("url3").build()
+    @BeforeEach
+    void setup() {
+        service = new MedicineSearchService(
+            List.of(portA, portB),
+            new JaroWinklerSimilarity(),
+            Runnable::run  // 동기 실행 executor
         );
-        given(port.searchByName("타이레")).willReturn(items);
-
-        MedicineSearchResponseDto response = service.searchByName("타이레");
-
-        assertThat(response.getMedicines())
-            .hasSize(3)
-            .containsExactlyElementsOf(items);
     }
 
     @Test
-    @DisplayName("포트에서 예외 발생 시 유스케이스가 swallow 없이 그대로 전파")
-    void searchByName_portThrows_propagatesException() {
-        RuntimeException boom = new RuntimeException("adapter failed");
-        given(port.searchByName("타이레놀")).willThrow(boom);
+    @DisplayName("모든 포트가 빈 리스트면 빈 응답")
+    void allEmpty_returnsEmpty() {
+        given(portA.searchByName(anyString())).willReturn(Collections.emptyList());
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
 
-        assertThatThrownBy(() -> service.searchByName("타이레놀"))
-            .isSameAs(boom);
+        MedicineSearchResponseDto result = service.searchByName("없는약");
+
+        assertThat(result.getMedicines()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 포트 결과 병합 후 쿼리 유사도 내림차순 정렬")
+    void mergeAndSortBySimilarity() {
+        given(portA.searchByName("타이레놀")).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀펜").source("MFDS").build()
+        ));
+        given(portB.searchByName("타이레놀")).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").source("FDA").build()
+        ));
+
+        MedicineSearchResponseDto result = service.searchByName("타이레놀");
+
+        assertThat(result.getMedicines())
+            .extracting(MedicineSearchItemDto::getName)
+            .containsExactly("타이레놀", "타이레놀펜");
+    }
+
+    @Test
+    @DisplayName("정규화된 이름이 같으면 중복 제거")
+    void dedupByNormalizedName() {
+        given(portA.searchByName("타이레놀")).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀 500mg").source("MFDS").build()
+        ));
+        given(portB.searchByName("타이레놀")).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").source("FDA").build()
+        ));
+
+        MedicineSearchResponseDto result = service.searchByName("타이레놀");
+
+        assertThat(result.getMedicines()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("한 어댑터가 예외를 던져도 다른 어댑터 결과는 살아남는다")
+    void adapterFailureIsolated() {
+        given(portA.searchByName(anyString())).willThrow(new RuntimeException("MFDS down"));
+        given(portB.searchByName(anyString())).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").source("FDA").build()
+        ));
+
+        MedicineSearchResponseDto result = service.searchByName("타이레놀");
+
+        assertThat(result.getMedicines())
+            .hasSize(1)
+            .extracting(MedicineSearchItemDto::getName)
+            .containsExactly("타이레놀");
+    }
+
+    @Test
+    @DisplayName("포트가 null 리턴해도 NPE 없이 빈 결과 처리")
+    void nullResult_handledSafely() {
+        given(portA.searchByName(anyString())).willReturn(null);
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
+
+        MedicineSearchResponseDto result = service.searchByName("x");
+
+        assertThat(result.getMedicines()).isEmpty();
     }
 }

--- a/api/src/test/java/com/mediforme/mediforme/search/support/JaroWinklerSimilarityTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/support/JaroWinklerSimilarityTest.java
@@ -1,0 +1,48 @@
+package com.mediforme.mediforme.search.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JaroWinklerSimilarityTest {
+
+    private final JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
+
+    @Test
+    @DisplayName("완전 일치는 1.0")
+    void exactMatch() {
+        assertThat(similarity.score("타이레놀", "타이레놀")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("null/빈 문자열은 0.0")
+    void nullOrEmpty() {
+        assertThat(similarity.score(null, "x")).isEqualTo(0.0);
+        assertThat(similarity.score("x", null)).isEqualTo(0.0);
+        assertThat(similarity.score("", "x")).isEqualTo(0.0);
+        assertThat(similarity.score("x", "")).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("접두사 일치는 가산점 (Winkler)")
+    void prefixBoost() {
+        double withPrefix = similarity.score("타이레놀정", "타이레놀");
+        double withoutPrefix = similarity.score("놀정타이레", "타이레놀");
+        assertThat(withPrefix).isGreaterThan(withoutPrefix);
+    }
+
+    @Test
+    @DisplayName("완전 불일치는 낮은 점수")
+    void completelyDifferent() {
+        double s = similarity.score("타이레놀", "아스피린");
+        assertThat(s).isLessThan(0.5);
+    }
+
+    @Test
+    @DisplayName("한 글자 차이는 높은 점수 (OCR 오타 시나리오)")
+    void nearMatchHighScore() {
+        double s = similarity.score("타이레놀", "타이래놀");
+        assertThat(s).isGreaterThan(0.8);
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/support/TextNormalizerTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/support/TextNormalizerTest.java
@@ -1,0 +1,53 @@
+package com.mediforme.mediforme.search.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextNormalizerTest {
+
+    @Test
+    @DisplayName("null/빈 문자열은 빈 문자열 반환")
+    void nullOrBlank() {
+        assertThat(TextNormalizer.normalize(null)).isEmpty();
+        assertThat(TextNormalizer.normalize("")).isEmpty();
+        assertThat(TextNormalizer.normalize("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("공백·특수문자 제거")
+    void stripsWhitespaceAndSymbols() {
+        assertThat(TextNormalizer.normalize("타이레놀 500")).isEqualTo("타이레놀500");
+        assertThat(TextNormalizer.normalize("Ty-le-nol!")).isEqualTo("tylenol");
+    }
+
+    @Test
+    @DisplayName("용량 단위 제거 (mg, ml, 밀리그램 등)")
+    void stripsDosage() {
+        assertThat(TextNormalizer.normalize("타이레놀 500mg")).isEqualTo("타이레놀");
+        assertThat(TextNormalizer.normalize("아스피린 100 mg")).isEqualTo("아스피린");
+        assertThat(TextNormalizer.normalize("Tylenol 500MG")).isEqualTo("tylenol");
+    }
+
+    @Test
+    @DisplayName("괄호와 괄호 안 내용 제거")
+    void stripsParens() {
+        assertThat(TextNormalizer.normalize("타이레놀(아세트아미노펜)"))
+            .isEqualTo("타이레놀");
+    }
+
+    @Test
+    @DisplayName("대소문자 통일")
+    void lowercases() {
+        assertThat(TextNormalizer.normalize("Tylenol")).isEqualTo("tylenol");
+        assertThat(TextNormalizer.normalize("TYLENOL")).isEqualTo("tylenol");
+    }
+
+    @Test
+    @DisplayName("영문+숫자+한글 혼합")
+    void mixedAlphanumeric() {
+        assertThat(TextNormalizer.normalize("Tylenol 서방정 500mg"))
+            .isEqualTo("tylenol서방정");
+    }
+}


### PR DESCRIPTION
## 요약

Phase A 의 첫 번째 머지 단위. 검색 서비스의 구조를 다중 어댑터 병렬 호출로 전환하고, FDA/RxNorm 어댑터를 실제로 붙여 커버리지 문제 해소. OCR 전환 가능성 대비 `OcrPort` 선제 추출.

## 변경 내역

### 1. OcrPort 추출 (`676f259`)
`MedicineImageRecognitionServiceImpl` 이 `ImageAnnotatorClient` 에 직접 의존하던 구조를 제거. 도메인 서비스는 `OcrPort` 만 바라보고, Vision 특화 코드는 `GoogleVisionOcrAdapter` 로 격리.

### 2. 정규화·유사도 유틸 (`ab0cdbc`)
- `TextNormalizer` — 공백/괄호/용량/대소문자/특수문자 제거
- `JaroWinklerSimilarity` — 공통 접두사 가산점이 있는 유사도 스코어 (OCR 오타 대응)

### 3. 검색 서비스 병렬 호출 + 실패 격리 (`ea3374c`)
`MedicineSearchService` 재설계:

- `List<MedicineSearchPort>` 주입받아 병렬 호출 (`searchExecutor` Bean)
- 어댑터별 2 초 타임아웃
- 개별 어댑터 실패/타임아웃은 격리되어 다른 어댑터 결과는 생존
- 정규화 이름 기준 중복 제거 (같은 약 키로 수렴)
- 쿼리와의 Jaro-Winkler 유사도 내림차순 정렬
- `MedicineSearchItemDto` 에 `source` 필드 추가 (MFDS / FDA / RxNorm 추적)
- `MfdsMedicineSearchAdapter` 도 실패 격리 원칙에 맞게 throw → empty 전환

### 4. FDA / RxNorm 어댑터 스켈레톤 + 구현 (`37f2fc2`, `cd70a03`, `4053a78`)

openFDA drug label:
```
GET /drug/label.json?search=openfda.brand_name:"{name}" OR openfda.generic_name:"{name}"&limit=10
```
- `brand_name` 우선, 없으면 `generic_name` 으로 fallback
- 404 (매칭 없음) 은 예외 없이 빈 리스트로 변환
- Lucene 인젝션 방지용 sanitization (영문/숫자/한글/공백만)

NIH RxNorm approximateTerm:
```
GET /approximateTerm.json?term={name}&maxEntries=10
```
- OCR 오타 복원 용도 — "Tyenol" → "Tylenol" 제안
- 동일 rxcui 중복 제거
- 이미지 URL 미제공

둘 다 Spring `RestClient` 사용 (Spring Boot 3.3 표준).

## 영향 범위

```
api/src/main/java/com/mediforme/mediforme/search/**
api/src/main/java/com/mediforme/mediforme/medicine/external/**
api/src/main/java/com/mediforme/mediforme/medicine/dto/MedicineSearchItemDto.java
api/src/main/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImpl.java
```

## 응답 계약

`GET /medicines?name=...` 의 응답 스키마는 불변. `source` 필드가 추가되었으나 기존 필드 (`name`, `imageUrl`) 는 그대로.

## 테스트

- 기존 73건 + 신규 23건 = **96건 통과**
- `TextNormalizerTest` — 정규화 경계 케이스 6건
- `JaroWinklerSimilarityTest` — 완전 일치/접두사 가산/불일치/오타 5건
- `MedicineSearchServiceTest` 재작성 — 병합/유사도 정렬/중복 제거/실패 격리/null 처리 5건
- `FdaMedicineSearchAdapterTest` — brand 우선/generic fallback/스킵/빈 결과/예외 격리 5건
- `RxNormMedicineSearchAdapterTest` — 매핑/rxcui 중복 제거/스킵/빈 결과/예외 격리 5건

## 후속 작업 (별도 이슈/PR)

- Micrometer 메트릭 — 어댑터별 latency·성공률·실패 유형 태깅
- `GET /medicines` MockMvc HTTP 통합 테스트
- openFDA API 키 발급 및 rate limit 확대