### PR TITLE
feat: 검색·OCR 메트릭 및 구조화 로깅 추가

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImpl.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImpl.java
@@ -3,6 +3,7 @@ package com.mediforme.mediforme.medicine.service.impl;
 import com.mediforme.mediforme.medicine.dto.MedicineRecognitionResultDto;
 import com.mediforme.mediforme.medicine.external.port.OcrPort;
 import com.mediforme.mediforme.medicine.service.MedicineImageRecognitionService;
+import com.mediforme.mediforme.medicine.support.OcrMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.text.Normalizer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 public class MedicineImageRecognitionServiceImpl implements MedicineImageRecognitionService {
 
     private final OcrPort ocrPort;
+    private final OcrMetrics metrics;
 
     // 후보 최대 개수 (외부 API 호출 폭증 방지)
     private static final int MAX_CANDIDATES = 5;
@@ -65,17 +68,38 @@ public class MedicineImageRecognitionServiceImpl implements MedicineImageRecogni
             return empty();
         }
 
+        long start = System.nanoTime();
         try {
             String fullText = ocrPort.extractText(imageFile.getBytes());
-            if (fullText == null || fullText.isBlank()) return empty();
+            Duration duration = Duration.ofNanos(System.nanoTime() - start);
+
+            if (fullText == null || fullText.isBlank()) {
+                metrics.recordExtract(duration, OcrMetrics.Outcome.EMPTY, 0);
+                log.info("ocr result outcome=empty duration={}ms", duration.toMillis());
+                return empty();
+            }
+
+            List<String> candidates = extractCandidates(fullText);
+            metrics.recordExtract(duration, OcrMetrics.Outcome.SUCCESS, fullText.length());
+            log.info("ocr result raw_length={} candidates={} outcome=success duration={}ms",
+                fullText.length(), candidates.size(), duration.toMillis());
 
             return MedicineRecognitionResultDto.builder()
                 .fullText(fullText)
-                .candidates(extractCandidates(fullText))
+                .candidates(candidates)
                 .build();
 
         } catch (IOException e) {
-            log.warn("Image read failed", e);
+            Duration duration = Duration.ofNanos(System.nanoTime() - start);
+            metrics.recordExtract(duration, OcrMetrics.Outcome.FAILURE, -1);
+            log.warn("ocr image read failed duration={}ms: {}",
+                duration.toMillis(), e.getMessage());
+            return empty();
+        } catch (Exception e) {
+            Duration duration = Duration.ofNanos(System.nanoTime() - start);
+            metrics.recordExtract(duration, OcrMetrics.Outcome.FAILURE, -1);
+            log.warn("ocr unexpected failure duration={}ms: {}",
+                duration.toMillis(), e.getMessage());
             return empty();
         }
     }

--- a/api/src/main/java/com/mediforme/mediforme/medicine/support/OcrMetrics.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/support/OcrMetrics.java
@@ -1,0 +1,37 @@
+package com.mediforme.mediforme.medicine.support;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * OCR 파이프라인 메트릭
+ */
+@Component
+@RequiredArgsConstructor
+public class OcrMetrics {
+
+    private final MeterRegistry registry;
+
+    public void recordExtract(Duration duration, Outcome outcome, int textLength) {
+        Timer.builder("ocr.extract.duration")
+            .tag("outcome", outcome.tag())
+            .register(registry)
+            .record(duration);
+
+        if (textLength >= 0) {
+            DistributionSummary.builder("ocr.extract.text_length")
+                .register(registry)
+                .record(textLength);
+        }
+    }
+
+    public enum Outcome {
+        SUCCESS, EMPTY, FAILURE;
+        public String tag() { return name().toLowerCase(); }
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/FdaMedicineSearchAdapter.java
@@ -27,6 +27,9 @@ public class FdaMedicineSearchAdapter implements MedicineSearchPort {
     private final FdaDrugLabelClient client;
 
     @Override
+    public String name() { return SOURCE; }
+
+    @Override
     public List<MedicineSearchItemDto> searchByName(String itemName) {
         try {
             List<Map<String, Object>> openfdas = client.fetchOpenFdaByName(itemName);

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/MfdsMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/MfdsMedicineSearchAdapter.java
@@ -27,6 +27,9 @@ public class MfdsMedicineSearchAdapter implements MedicineSearchPort {
     private final MfdsMedicineClient mfdsClient;
 
     @Override
+    public String name() { return SOURCE; }
+
+    @Override
     public List<MedicineSearchItemDto> searchByName(String itemName) {
         try {
             JSONArray items = mfdsClient.fetchItemsByName(itemName);

--- a/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/adapter/RxNormMedicineSearchAdapter.java
@@ -29,6 +29,9 @@ public class RxNormMedicineSearchAdapter implements MedicineSearchPort {
     private final RxNormClient client;
 
     @Override
+    public String name() { return SOURCE; }
+
+    @Override
     public List<MedicineSearchItemDto> searchByName(String itemName) {
         try {
             List<Map<String, Object>> candidates = client.fetchApproximateCandidates(itemName);

--- a/api/src/main/java/com/mediforme/mediforme/search/application/MedicineSearchService.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/application/MedicineSearchService.java
@@ -4,25 +4,30 @@ import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchResponseDto;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
 import com.mediforme.mediforme.search.support.JaroWinklerSimilarity;
+import com.mediforme.mediforme.search.support.SearchMetrics;
 import com.mediforme.mediforme.search.support.TextNormalizer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * 약 검색 유스케이스
  * - 여러 MedicineSearchPort를 병렬 호출 후 결과 병합
  * - 정규화된 이름 기준 중복 제거, 쿼리 유사도 내림차순 정렬
- * - 개별 어댑터 실패/타임아웃은 격리
+ * - 개별 어댑터 실패/타임아웃은 격리하며 메트릭으로 기록
  */
 @Slf4j
 @Service
@@ -33,32 +38,36 @@ public class MedicineSearchService {
     private final List<MedicineSearchPort> ports;
     private final JaroWinklerSimilarity similarity;
     private final Executor executor;
+    private final SearchMetrics metrics;
 
     public MedicineSearchService(List<MedicineSearchPort> ports,
                                  JaroWinklerSimilarity similarity,
-                                 @Qualifier("searchExecutor") Executor executor) {
+                                 @Qualifier("searchExecutor") Executor executor,
+                                 SearchMetrics metrics) {
         this.ports = ports;
         this.similarity = similarity;
         this.executor = executor;
+        this.metrics = metrics;
     }
 
     public MedicineSearchResponseDto searchByName(String name) {
         String normalizedQuery = TextNormalizer.normalize(name);
+        log.info("search query name='{}' normalized='{}'", name, normalizedQuery);
 
-        List<CompletableFuture<List<MedicineSearchItemDto>>> futures = ports.stream()
-            .map(port -> CompletableFuture
-                .supplyAsync(() -> safeSearch(port, name), executor)
-                .orTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                .exceptionally(ex -> {
-                    log.warn("adapter {} timed out or failed: {}",
-                        port.getClass().getSimpleName(), ex.getMessage());
-                    return Collections.emptyList();
-                }))
+        List<CompletableFuture<AdapterResult>> futures = ports.stream()
+            .map(port -> callAdapter(port, name))
             .toList();
 
         Map<String, Scored> best = new LinkedHashMap<>();
-        for (CompletableFuture<List<MedicineSearchItemDto>> f : futures) {
-            for (MedicineSearchItemDto item : f.join()) {
+        Set<String> adaptersHit = new LinkedHashSet<>();
+
+        for (CompletableFuture<AdapterResult> f : futures) {
+            AdapterResult r = f.join();
+            if (!r.items.isEmpty()) {
+                adaptersHit.add(r.adapterName);
+                metrics.recordSourceHit(r.adapterName);
+            }
+            for (MedicineSearchItemDto item : r.items) {
                 String key = TextNormalizer.normalize(item.getName());
                 if (key.isEmpty()) continue;
                 double score = similarity.score(normalizedQuery, key);
@@ -72,18 +81,49 @@ public class MedicineSearchService {
             .map(s -> s.item)
             .toList();
 
+        metrics.recordQuery(!merged.isEmpty());
+        log.info("search done count={} adapters_hit={}", merged.size(), adaptersHit);
+
         return MedicineSearchResponseDto.builder().medicines(merged).build();
     }
 
-    private List<MedicineSearchItemDto> safeSearch(MedicineSearchPort port, String name) {
-        try {
-            List<MedicineSearchItemDto> r = port.searchByName(name);
-            return r != null ? r : Collections.emptyList();
-        } catch (Exception e) {
-            log.warn("adapter {} threw: {}", port.getClass().getSimpleName(), e.getMessage());
-            return Collections.emptyList();
-        }
+    private CompletableFuture<AdapterResult> callAdapter(MedicineSearchPort port, String name) {
+        String adapterName = port.name();
+        long start = System.nanoTime();
+
+        return CompletableFuture
+            .supplyAsync(() -> {
+                List<MedicineSearchItemDto> raw = port.searchByName(name);
+                List<MedicineSearchItemDto> items = raw != null ? raw : Collections.emptyList();
+                Duration duration = Duration.ofNanos(System.nanoTime() - start);
+                metrics.recordAdapterCall(adapterName, duration,
+                    SearchMetrics.Outcome.SUCCESS, items.size());
+                log.debug("adapter {} success count={} duration={}ms",
+                    adapterName, items.size(), duration.toMillis());
+                return new AdapterResult(adapterName, items);
+            }, executor)
+            .orTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .exceptionally(ex -> {
+                Duration duration = Duration.ofNanos(System.nanoTime() - start);
+                SearchMetrics.Outcome outcome = isTimeout(ex)
+                    ? SearchMetrics.Outcome.TIMEOUT
+                    : SearchMetrics.Outcome.FAILURE;
+                metrics.recordAdapterCall(adapterName, duration, outcome, 0);
+                log.warn("adapter {} {} duration={}ms: {}",
+                    adapterName, outcome.tag(), duration.toMillis(), ex.getMessage());
+                return new AdapterResult(adapterName, Collections.emptyList());
+            });
     }
 
+    private boolean isTimeout(Throwable ex) {
+        Throwable t = ex;
+        while (t != null) {
+            if (t instanceof TimeoutException) return true;
+            t = t.getCause();
+        }
+        return false;
+    }
+
+    private record AdapterResult(String adapterName, List<MedicineSearchItemDto> items) {}
     private record Scored(MedicineSearchItemDto item, double score) {}
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/port/MedicineSearchPort.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/port/MedicineSearchPort.java
@@ -13,4 +13,11 @@ public interface MedicineSearchPort {
      * 약 이름을 통한 검색
      */
     List<MedicineSearchItemDto> searchByName(String itemName);
+
+    /**
+     * 어댑터 이름 (메트릭 태그·로깅용)
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
 }

--- a/api/src/main/java/com/mediforme/mediforme/search/support/SearchMetrics.java
+++ b/api/src/main/java/com/mediforme/mediforme/search/support/SearchMetrics.java
@@ -1,0 +1,46 @@
+package com.mediforme.mediforme.search.support;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * 검색 파이프라인 메트릭
+ */
+@Component
+@RequiredArgsConstructor
+public class SearchMetrics {
+
+    private final MeterRegistry registry;
+
+    public void recordAdapterCall(String adapter, Duration duration, Outcome outcome, int resultCount) {
+        Timer.builder("search.adapter.duration")
+            .tag("adapter", adapter)
+            .tag("outcome", outcome.tag())
+            .register(registry)
+            .record(duration);
+
+        DistributionSummary.builder("search.adapter.result_count")
+            .tag("adapter", adapter)
+            .register(registry)
+            .record(resultCount);
+    }
+
+    public void recordQuery(boolean hasResults) {
+        registry.counter("search.query.total",
+            "has_results", String.valueOf(hasResults)).increment();
+    }
+
+    public void recordSourceHit(String adapter) {
+        registry.counter("search.query.sources_hit", "adapter", adapter).increment();
+    }
+
+    public enum Outcome {
+        SUCCESS, FAILURE, TIMEOUT;
+        public String tag() { return name().toLowerCase(); }
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImplTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/medicine/service/impl/MedicineImageRecognitionServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.mediforme.mediforme.medicine.service.impl;
+
+import com.mediforme.mediforme.medicine.dto.MedicineRecognitionResultDto;
+import com.mediforme.mediforme.medicine.external.port.OcrPort;
+import com.mediforme.mediforme.medicine.support.OcrMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MedicineImageRecognitionServiceImplTest {
+
+    @Mock private OcrPort ocrPort;
+
+    private MeterRegistry registry;
+    private MedicineImageRecognitionServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry();
+        OcrMetrics metrics = new OcrMetrics(registry);
+        service = new MedicineImageRecognitionServiceImpl(ocrPort, metrics);
+    }
+
+    private MultipartFile sampleImage() {
+        return new MockMultipartFile("file", "img.jpg", "image/jpeg", new byte[]{1, 2, 3});
+    }
+
+    @Test
+    @DisplayName("빈 이미지는 메트릭 기록 없이 빈 결과")
+    void emptyImage_noMetric() {
+        MultipartFile empty = new MockMultipartFile("file", new byte[0]);
+
+        MedicineRecognitionResultDto result = service.recognizeMedicineCandidates(empty);
+
+        assertThat(result.getCandidates()).isEmpty();
+        assertThat(registry.find("ocr.extract.duration").timer()).isNull();
+    }
+
+    @Test
+    @DisplayName("OCR 성공 시 SUCCESS outcome 메트릭과 텍스트 길이 기록")
+    void success_recordsSuccess() {
+        given(ocrPort.extractText(any())).willReturn("타이레놀\n500mg");
+
+        MedicineRecognitionResultDto result = service.recognizeMedicineCandidates(sampleImage());
+
+        assertThat(result.getFullText()).isNotBlank();
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "success").timer().count()).isEqualTo(1);
+        assertThat(registry.find("ocr.extract.text_length").summary().totalAmount())
+            .isEqualTo("타이레놀\n500mg".length());
+    }
+
+    @Test
+    @DisplayName("OCR이 null 반환하면 EMPTY outcome 메트릭")
+    void nullOcr_recordsEmpty() {
+        given(ocrPort.extractText(any())).willReturn(null);
+
+        MedicineRecognitionResultDto result = service.recognizeMedicineCandidates(sampleImage());
+
+        assertThat(result.getCandidates()).isEmpty();
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "empty").timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("OCR 빈 문자열도 EMPTY outcome")
+    void blankOcr_recordsEmpty() {
+        given(ocrPort.extractText(any())).willReturn("   ");
+
+        service.recognizeMedicineCandidates(sampleImage());
+
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "empty").timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("OcrPort 예외 시 FAILURE outcome 메트릭")
+    void ocrThrows_recordsFailure() {
+        given(ocrPort.extractText(any())).willThrow(new RuntimeException("vision down"));
+
+        MedicineRecognitionResultDto result = service.recognizeMedicineCandidates(sampleImage());
+
+        assertThat(result.getCandidates()).isEmpty();
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "failure").timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("recognizeMedicineName은 1순위 후보만 반환")
+    void recognizeMedicineName_returnsTopCandidate() {
+        given(ocrPort.extractText(any())).willReturn("타이레놀정\n아세트아미노펜");
+
+        String name = service.recognizeMedicineName(sampleImage());
+
+        assertThat(name).isNotNull();
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/medicine/support/OcrMetricsTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/medicine/support/OcrMetricsTest.java
@@ -1,0 +1,63 @@
+package com.mediforme.mediforme.medicine.support;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OcrMetricsTest {
+
+    private MeterRegistry registry;
+    private OcrMetrics metrics;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry();
+        metrics = new OcrMetrics(registry);
+    }
+
+    @Test
+    @DisplayName("OCR 추출 기록 — Timer 와 텍스트 길이 분포")
+    void recordExtract() {
+        metrics.recordExtract(Duration.ofMillis(800),
+            OcrMetrics.Outcome.SUCCESS, 150);
+
+        var timer = registry.find("ocr.extract.duration")
+            .tag("outcome", "success").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+
+        var summary = registry.find("ocr.extract.text_length").summary();
+        assertThat(summary).isNotNull();
+        assertThat(summary.count()).isEqualTo(1);
+        assertThat(summary.totalAmount()).isEqualTo(150.0);
+    }
+
+    @Test
+    @DisplayName("EMPTY / FAILURE 도 outcome 태그로 구분")
+    void outcomesAreTagged() {
+        metrics.recordExtract(Duration.ofMillis(100), OcrMetrics.Outcome.EMPTY, 0);
+        metrics.recordExtract(Duration.ofMillis(50), OcrMetrics.Outcome.FAILURE, -1);
+
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "empty").timer().count()).isEqualTo(1);
+        assertThat(registry.find("ocr.extract.duration")
+            .tag("outcome", "failure").timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("textLength < 0 인 경우 분포 기록 스킵")
+    void negativeLengthSkipped() {
+        metrics.recordExtract(Duration.ofMillis(50), OcrMetrics.Outcome.FAILURE, -1);
+
+        var summary = registry.find("ocr.extract.text_length").summary();
+        if (summary != null) {
+            assertThat(summary.count()).isEqualTo(0);
+        }
+    }
+}

--- a/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/application/MedicineSearchServiceTest.java
@@ -4,6 +4,9 @@ import com.mediforme.mediforme.medicine.dto.MedicineSearchItemDto;
 import com.mediforme.mediforme.medicine.dto.MedicineSearchResponseDto;
 import com.mediforme.mediforme.search.port.MedicineSearchPort;
 import com.mediforme.mediforme.search.support.JaroWinklerSimilarity;
+import com.mediforme.mediforme.search.support.SearchMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +20,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class MedicineSearchServiceTest {
@@ -24,15 +28,21 @@ class MedicineSearchServiceTest {
     @Mock private MedicineSearchPort portA;
     @Mock private MedicineSearchPort portB;
 
+    private MeterRegistry registry;
     private MedicineSearchService service;
 
     @BeforeEach
     void setup() {
+        registry = new SimpleMeterRegistry();
+        SearchMetrics metrics = new SearchMetrics(registry);
         service = new MedicineSearchService(
             List.of(portA, portB),
             new JaroWinklerSimilarity(),
-            Runnable::run  // 동기 실행 executor
+            Runnable::run,  // 동기 실행 executor
+            metrics
         );
+        lenient().when(portA.name()).thenReturn("A");
+        lenient().when(portB.name()).thenReturn("B");
     }
 
     @Test
@@ -81,7 +91,7 @@ class MedicineSearchServiceTest {
     @Test
     @DisplayName("한 어댑터가 예외를 던져도 다른 어댑터 결과는 살아남는다")
     void adapterFailureIsolated() {
-        given(portA.searchByName(anyString())).willThrow(new RuntimeException("MFDS down"));
+        given(portA.searchByName(anyString())).willThrow(new RuntimeException("down"));
         given(portB.searchByName(anyString())).willReturn(List.of(
             MedicineSearchItemDto.builder().name("타이레놀").source("FDA").build()
         ));
@@ -103,5 +113,70 @@ class MedicineSearchServiceTest {
         MedicineSearchResponseDto result = service.searchByName("x");
 
         assertThat(result.getMedicines()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("성공 호출은 SUCCESS outcome 메트릭 기록")
+    void metric_successOutcome() {
+        given(portA.searchByName(anyString())).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").build()
+        ));
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
+
+        service.searchByName("타이레놀");
+
+        assertThat(registry.find("search.adapter.duration")
+            .tag("adapter", "A").tag("outcome", "success").timer().count())
+            .isEqualTo(1);
+        assertThat(registry.find("search.adapter.duration")
+            .tag("adapter", "B").tag("outcome", "success").timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("예외 호출은 FAILURE outcome 메트릭 기록")
+    void metric_failureOutcome() {
+        given(portA.searchByName(anyString())).willThrow(new RuntimeException("down"));
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
+
+        service.searchByName("x");
+
+        assertThat(registry.find("search.adapter.duration")
+            .tag("adapter", "A").tag("outcome", "failure").timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("소스 히트는 결과를 기여한 어댑터만 기록")
+    void metric_sourceHit_onlyContributing() {
+        given(portA.searchByName(anyString())).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").build()
+        ));
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
+
+        service.searchByName("타이레놀");
+
+        assertThat(registry.find("search.query.sources_hit")
+            .tag("adapter", "A").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("search.query.sources_hit")
+            .tag("adapter", "B").counter()).isNull();
+    }
+
+    @Test
+    @DisplayName("쿼리 총계는 결과 유무에 따라 분기")
+    void metric_queryHasResultsTag() {
+        given(portA.searchByName(anyString())).willReturn(List.of(
+            MedicineSearchItemDto.builder().name("타이레놀").build()
+        ));
+        given(portB.searchByName(anyString())).willReturn(Collections.emptyList());
+        service.searchByName("타이레놀");
+
+        given(portA.searchByName(anyString())).willReturn(Collections.emptyList());
+        service.searchByName("없는약");
+
+        assertThat(registry.find("search.query.total")
+            .tag("has_results", "true").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("search.query.total")
+            .tag("has_results", "false").counter().count()).isEqualTo(1.0);
     }
 }

--- a/api/src/test/java/com/mediforme/mediforme/search/support/SearchMetricsTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/search/support/SearchMetricsTest.java
@@ -1,0 +1,88 @@
+package com.mediforme.mediforme.search.support;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchMetricsTest {
+
+    private MeterRegistry registry;
+    private SearchMetrics metrics;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry();
+        metrics = new SearchMetrics(registry);
+    }
+
+    @Test
+    @DisplayName("어댑터 호출 기록 — Timer + ResultCount 각 태그로 저장")
+    void recordAdapterCall() {
+        metrics.recordAdapterCall("MFDS", Duration.ofMillis(120),
+            SearchMetrics.Outcome.SUCCESS, 3);
+
+        var timer = registry.find("search.adapter.duration")
+            .tag("adapter", "MFDS")
+            .tag("outcome", "success")
+            .timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+
+        var summary = registry.find("search.adapter.result_count")
+            .tag("adapter", "MFDS")
+            .summary();
+        assertThat(summary).isNotNull();
+        assertThat(summary.count()).isEqualTo(1);
+        assertThat(summary.totalAmount()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("타임아웃/실패도 outcome 태그로 구분")
+    void outcomesAreTagged() {
+        metrics.recordAdapterCall("FDA", Duration.ofSeconds(2),
+            SearchMetrics.Outcome.TIMEOUT, 0);
+        metrics.recordAdapterCall("RxNorm", Duration.ofMillis(50),
+            SearchMetrics.Outcome.FAILURE, 0);
+
+        assertThat(registry.find("search.adapter.duration")
+            .tag("adapter", "FDA").tag("outcome", "timeout").timer().count())
+            .isEqualTo(1);
+        assertThat(registry.find("search.adapter.duration")
+            .tag("adapter", "RxNorm").tag("outcome", "failure").timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("쿼리 총계 — has_results 태그로 분기")
+    void recordQuery() {
+        metrics.recordQuery(true);
+        metrics.recordQuery(false);
+        metrics.recordQuery(true);
+
+        assertThat(registry.find("search.query.total")
+            .tag("has_results", "true").counter().count())
+            .isEqualTo(2.0);
+        assertThat(registry.find("search.query.total")
+            .tag("has_results", "false").counter().count())
+            .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("소스 히트 — 어댑터별 집계")
+    void recordSourceHit() {
+        metrics.recordSourceHit("MFDS");
+        metrics.recordSourceHit("MFDS");
+        metrics.recordSourceHit("FDA");
+
+        assertThat(registry.find("search.query.sources_hit")
+            .tag("adapter", "MFDS").counter().count()).isEqualTo(2.0);
+        assertThat(registry.find("search.query.sources_hit")
+            .tag("adapter", "FDA").counter().count()).isEqualTo(1.0);
+    }
+}


### PR DESCRIPTION
## 요약

Phase A 의 두 번째 머지 단위. 검색/OCR 파이프라인에 Micrometer 메트릭과 구조화 로그를 붙여 효과 측정 기반을 마련.

## 변경 내역

### 1. 메트릭 헬퍼 (`a2e12ea`)

- `SearchMetrics` — 검색 파이프라인 메트릭
  - `search.adapter.duration` (Timer, `adapter`/`outcome`)
  - `search.adapter.result_count` (DistributionSummary, `adapter`)
  - `search.query.total` (Counter, `has_results`)
  - `search.query.sources_hit` (Counter, `adapter`)
- `OcrMetrics` — OCR 파이프라인 메트릭
  - `ocr.extract.duration` (Timer, `outcome`)
  - `ocr.extract.text_length` (DistributionSummary)
- outcome 값은 `Outcome` enum 으로 캡슐화 (오타 방지)

### 2. 검색 서비스 통합 (`743042f`)

- `MedicineSearchPort` 에 `default name()` 추가 — 메트릭 태그값이 DTO `source` 필드와 일치 (MFDS/FDA/RxNorm)
- `MedicineSearchService.callAdapter()` — CompletableFuture 내부에서 start/end 측정, outcome(success/failure/timeout) 태깅
- `TimeoutException` 체인 검사로 FAILURE vs TIMEOUT 구분
- `adaptersHit` 셋으로 `sources_hit` 카운터 기록
- 진입/종료 `log.info`, 어댑터별 성공 `debug`, 실패 `warn`

### 3. OCR 서비스 통합 (`63c929f`)

| 케이스 | 메트릭 |
|---|---|
| 빈 이미지 | 미기록 (invalid input) |
| OCR null/blank | EMPTY |
| OCR 성공 | SUCCESS + text_length |
| IOException / 기타 예외 | FAILURE |

## 응답 계약

외부 응답 스키마 변경 없음. 기존 동작 보존.

## 테스트

- 기존 96건 + 신규 17건 = **113건 통과**
- `SearchMetricsTest` — 어댑터 호출/outcome 태깅/쿼리 총계/소스 히트 4건
- `OcrMetricsTest` — 추출 기록/outcome 태깅/음수 길이 스킵 3건
- `MedicineSearchServiceTest` — 메트릭 검증 4건 추가 (success/failure/source hit/has_results)
- `MedicineImageRecognitionServiceImplTest` 신규 — 빈 이미지/성공/null/blank/예외/name 추출 6건

## 확인 방법

```
curl -s http://localhost:8080/actuator/prometheus | grep -E '^(search|ocr)_'
```

대표 출력:
```
search_adapter_duration_seconds_count{adapter="MFDS",outcome="success"} 1.0
search_adapter_result_count_count{adapter="MFDS"} 1.0
search_query_total_total{has_results="true"} 1.0
ocr_extract_duration_seconds_count{outcome="success"} 1.0
```

## 후속 작업 (별도 이슈/PR)

- \`GET /medicines\` MockMvc HTTP 통합 테스트
- Grafana 대시보드 (트래픽 축적 후)
- openFDA API 키 발급


## 관련 이슈
closes #48 