### PR TITLE
[FEAT] Chatbot Version B — 약 메타데이터 앵커링 구현 (#54)

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/chatbot/dto/ChatbotQuestionRequestDto.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/dto/ChatbotQuestionRequestDto.java
@@ -1,11 +1,19 @@
 package com.mediforme.mediforme.chatbot.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Getter
+@NoArgsConstructor
 public class ChatbotQuestionRequestDto implements Serializable {
-    @jakarta.validation.constraints.NotBlank(message = "질문 내용은 필수 입력 항목입니다.")
+
+    @NotBlank(message = "질문 내용은 필수 입력 항목입니다.")
     private String question;
+
+    @Valid
+    private MedicineContextDto medicineContext;
 }

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/dto/MedicineContextDto.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/dto/MedicineContextDto.java
@@ -1,0 +1,42 @@
+package com.mediforme.mediforme.chatbot.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MedicineContextDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Size(max = 200)
+    private String nameKo;
+
+    @Size(max = 200)
+    private String ingredientKo;
+
+    @Size(max = 20)
+    private String rxOtc;
+
+    @Size(max = 1000)
+    private String indicationsSummary;
+
+    @Size(max = 1000)
+    private String warningsSummary;
+
+    public boolean hasAny() {
+        return isPresent(nameKo) || isPresent(ingredientKo) || isPresent(rxOtc)
+                || isPresent(indicationsSummary) || isPresent(warningsSummary);
+    }
+
+    private static boolean isPresent(String v) {
+        return v != null && !v.isBlank();
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilder.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilder.java
@@ -1,0 +1,46 @@
+package com.mediforme.mediforme.chatbot.service;
+
+import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto.Message;
+import com.mediforme.mediforme.chatbot.dto.MedicineContextDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ChatbotPromptBuilder {
+
+    private static final String SYSTEM_PROMPT_HEADER =
+            "당신은 한국 사용자에게 의약품 정보를 설명하는 보조 챗봇입니다.\n"
+                    + "현재 대화는 아래 약에 대한 질문이므로, 이 약의 범위를 벗어난 일반론으로 빗나가지 마세요.\n"
+                    + "불확실하거나 안전에 영향이 있는 사안은 반드시 '의사·약사와 상담'을 안내하고, "
+                    + "처방 변경을 단독으로 지시하지 마세요.\n\n"
+                    + "약 컨텍스트:";
+
+    private ChatbotPromptBuilder() {
+    }
+
+    public static List<Message> build(String question, MedicineContextDto ctx) {
+        List<Message> messages = new ArrayList<>();
+        if (ctx != null && ctx.hasAny()) {
+            messages.add(new Message("system", buildSystemContent(ctx)));
+        }
+        messages.add(new Message("user", question));
+        return messages;
+    }
+
+    static String buildSystemContent(MedicineContextDto ctx) {
+        StringBuilder sb = new StringBuilder(SYSTEM_PROMPT_HEADER);
+        appendIfPresent(sb, "제품명", ctx.getNameKo());
+        appendIfPresent(sb, "성분", ctx.getIngredientKo());
+        appendIfPresent(sb, "구분", ctx.getRxOtc());
+        appendIfPresent(sb, "적응증 요약", ctx.getIndicationsSummary());
+        appendIfPresent(sb, "주의사항 요약", ctx.getWarningsSummary());
+        return sb.toString();
+    }
+
+    private static void appendIfPresent(StringBuilder sb, String label, String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        sb.append('\n').append("- ").append(label).append(": ").append(value);
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/service/impl/ChatbotServiceImpl.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/service/impl/ChatbotServiceImpl.java
@@ -4,6 +4,7 @@ import com.mediforme.mediforme.chatbot.external.OpenAIConfig;
 import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto;
 import com.mediforme.mediforme.chatbot.dto.ChatbotQuestionRequestDto;
 import com.mediforme.mediforme.chatbot.dto.ChatbotResponseDto;
+import com.mediforme.mediforme.chatbot.service.ChatbotPromptBuilder;
 import com.mediforme.mediforme.chatbot.service.ChatbotService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -11,8 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.Collections;
 
 @Service
 public class ChatbotServiceImpl implements ChatbotService {
@@ -37,10 +36,9 @@ public class ChatbotServiceImpl implements ChatbotService {
 
     @Override
     public ChatbotResponseDto askQuestion(ChatbotQuestionRequestDto requestDto) {
-        ChatbotRequestDto.Message message = new ChatbotRequestDto.Message("user", requestDto.getQuestion());
         ChatbotRequestDto chatGptRequestDto = new ChatbotRequestDto(
                 OpenAIConfig.MODEL,
-                Collections.singletonList(message)
+                ChatbotPromptBuilder.build(requestDto.getQuestion(), requestDto.getMedicineContext())
         );
         return this.getResponse(this.buildHttpEntity(chatGptRequestDto));
     }

--- a/api/src/test/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilderTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilderTest.java
@@ -1,0 +1,112 @@
+package com.mediforme.mediforme.chatbot.service;
+
+import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto.Message;
+import com.mediforme.mediforme.chatbot.dto.MedicineContextDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatbotPromptBuilderTest {
+
+    @Test
+    void 컨텍스트가_없으면_user_메시지만_포함한다() {
+        List<Message> messages = ChatbotPromptBuilder.build("타이레놀 먹어도 돼?", null);
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getRole()).isEqualTo("user");
+        assertThat(messages.get(0).getContent()).isEqualTo("타이레놀 먹어도 돼?");
+    }
+
+    @Test
+    void 모든_필드가_null_이면_user_메시지만_포함한다() {
+        MedicineContextDto empty = MedicineContextDto.builder().build();
+
+        List<Message> messages = ChatbotPromptBuilder.build("질문", empty);
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getRole()).isEqualTo("user");
+    }
+
+    @Test
+    void 공백만_있는_필드는_무시된다() {
+        MedicineContextDto blank = MedicineContextDto.builder()
+                .nameKo("   ")
+                .ingredientKo("")
+                .build();
+
+        List<Message> messages = ChatbotPromptBuilder.build("질문", blank);
+
+        assertThat(messages).hasSize(1);
+    }
+
+    @Test
+    void 컨텍스트가_있으면_system_메시지가_앞에_붙는다() {
+        MedicineContextDto ctx = MedicineContextDto.builder()
+                .nameKo("타이레놀")
+                .ingredientKo("아세트아미노펜")
+                .rxOtc("OTC")
+                .build();
+
+        List<Message> messages = ChatbotPromptBuilder.build("술 마셔도 돼?", ctx);
+
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getRole()).isEqualTo("system");
+        assertThat(messages.get(1).getRole()).isEqualTo("user");
+        assertThat(messages.get(1).getContent()).isEqualTo("술 마셔도 돼?");
+    }
+
+    @Test
+    void 시스템_프롬프트에_제공된_필드만_포함된다() {
+        MedicineContextDto ctx = MedicineContextDto.builder()
+                .nameKo("마운자로")
+                .ingredientKo("티르제파타이드")
+                .build();
+
+        String sys = ChatbotPromptBuilder.buildSystemContent(ctx);
+
+        assertThat(sys).contains("제품명: 마운자로");
+        assertThat(sys).contains("성분: 티르제파타이드");
+        assertThat(sys).doesNotContain("구분:");
+        assertThat(sys).doesNotContain("적응증 요약:");
+        assertThat(sys).doesNotContain("주의사항 요약:");
+    }
+
+    @Test
+    void 시스템_프롬프트에_안전_가드레일_문구가_포함된다() {
+        MedicineContextDto ctx = MedicineContextDto.builder()
+                .nameKo("팍스로비드")
+                .build();
+
+        String sys = ChatbotPromptBuilder.buildSystemContent(ctx);
+
+        assertThat(sys).contains("의사·약사와 상담");
+        assertThat(sys).contains("처방 변경을 단독으로 지시하지 마세요");
+    }
+
+    @Test
+    void 모든_메타데이터_필드가_순서대로_포함된다() {
+        MedicineContextDto ctx = MedicineContextDto.builder()
+                .nameKo("위고비")
+                .ingredientKo("세마글루티드")
+                .rxOtc("RX")
+                .indicationsSummary("만성 체중관리")
+                .warningsSummary("MTC/MEN 2 금기")
+                .build();
+
+        String sys = ChatbotPromptBuilder.buildSystemContent(ctx);
+
+        int nameIdx = sys.indexOf("제품명");
+        int ingredientIdx = sys.indexOf("성분");
+        int rxIdx = sys.indexOf("구분");
+        int indIdx = sys.indexOf("적응증 요약");
+        int warnIdx = sys.indexOf("주의사항 요약");
+
+        assertThat(nameIdx).isPositive();
+        assertThat(ingredientIdx).isGreaterThan(nameIdx);
+        assertThat(rxIdx).isGreaterThan(ingredientIdx);
+        assertThat(indIdx).isGreaterThan(rxIdx);
+        assertThat(warnIdx).isGreaterThan(indIdx);
+    }
+}

--- a/eval/chatbot-rag/run_eval.py
+++ b/eval/chatbot-rag/run_eval.py
@@ -21,9 +21,9 @@ from config import GOLDENSET_FILES, RESULTS_DIR  # noqa: E402
 from evaluators import keyword as kw_eval  # noqa: E402
 from evaluators import llm_judge  # noqa: E402
 from loader import load_goldenset  # noqa: E402
-from runners import version_a  # noqa: E402
+from runners import version_a, version_b_anchoring  # noqa: E402
 
-RUNNERS = {"A": version_a}
+RUNNERS = {"A": version_a, "B": version_b_anchoring}
 
 
 def parse_args() -> argparse.Namespace:

--- a/eval/chatbot-rag/runners/version_b_anchoring.py
+++ b/eval/chatbot-rag/runners/version_b_anchoring.py
@@ -1,0 +1,75 @@
+"""Version B — 약 메타데이터 앵커링 (RAG 아직 없음).
+
+Version A 와 같은 모델(gpt-3.5-turbo)을 쓰되, 골든셋의 drug 필드를 system 메시지로 주입.
+순수 "앵커링 효과" 를 분리해 측정 — 이후 Version C (RAG) 와 대비해
+앵커링만으로 얼마나 개선되는지 / RAG 가 추가로 얼마나 끌어올리는지 구분.
+"""
+import time
+from typing import Any
+
+from config import CHATBOT_MODEL, CHATBOT_TIMEOUT, OPENAI_API_KEY
+
+VERSION_NAME = "B-anchoring"
+
+_SYSTEM_TEMPLATE = (
+    "당신은 한국 사용자에게 의약품 정보를 설명하는 보조 챗봇입니다.\n"
+    "현재 대화는 아래 약에 대한 질문이므로, 이 약의 범위를 벗어난 일반론으로 빗나가지 마세요.\n"
+    "불확실하거나 안전에 영향이 있는 사안은 반드시 '의사·약사와 상담'을 안내하고, "
+    "처방 변경을 단독으로 지시하지 마세요.\n\n"
+    "약 컨텍스트:\n"
+    "- 제품명: {name_ko}\n"
+    "- 성분: {ingredient_ko}\n"
+    "- 구분: {rx_otc}"
+)
+
+
+def run(items: list[dict], dry_run: bool = False) -> list[dict]:
+    if dry_run:
+        return [_dry_answer(it) for it in items]
+    if not OPENAI_API_KEY:
+        raise RuntimeError("OPENAI_API_KEY not set — set env var or use --dry-run")
+    from openai import OpenAI  # lazy import
+    client = OpenAI(api_key=OPENAI_API_KEY, timeout=CHATBOT_TIMEOUT)
+    return [_ask(client, it) for it in items]
+
+
+def _ask(client, item: dict) -> dict:
+    system = _build_system(item["drug"])
+    started = time.perf_counter()
+    resp = client.chat.completions.create(
+        model=CHATBOT_MODEL,
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": item["question"]},
+        ],
+    )
+    latency_ms = (time.perf_counter() - started) * 1000
+    answer = resp.choices[0].message.content or ""
+    usage: Any = resp.usage
+    return {
+        "id": item["id"],
+        "answer": answer,
+        "latency_ms": round(latency_ms, 1),
+        "tokens_in": getattr(usage, "prompt_tokens", None),
+        "tokens_out": getattr(usage, "completion_tokens", None),
+        "model": CHATBOT_MODEL,
+    }
+
+
+def _build_system(drug: dict) -> str:
+    return _SYSTEM_TEMPLATE.format(
+        name_ko=drug.get("name_ko", "(미상)"),
+        ingredient_ko=drug.get("ingredient_ko", "(미상)"),
+        rx_otc=drug.get("rx_otc", "(미상)"),
+    )
+
+
+def _dry_answer(item: dict) -> dict:
+    return {
+        "id": item["id"],
+        "answer": f"[DRY-RUN anchored stub for {item['id']} — drug={item['drug']['name_ko']}]",
+        "latency_ms": 0.0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "model": "dry-run",
+    }


### PR DESCRIPTION
## 📌 개요

PR #53 에서 구축한 평가 환경의 **Version B** 구현.
RAG(Version C) 를 만들기 전, 검색에서 확정된 약의 메타데이터를 **시스템 프롬프트에 주입**하기만 하는 중간 단계.
목적:

- RAG 도입의 비용 대비 추가 이득이 얼마나 되는지 수치로 판단
- 앵커링만으로 충분한 질문 유형 / RAG 가 필요한 질문 유형 구분

## 🎯 도입한 것

### 1. 챗봇 요청 DTO 에 약 컨텍스트 필드 추가 (`78f5652`)

새 `MedicineContextDto` — 모두 optional 필드:

| 필드 | 용도 |
|---|---|
| `nameKo` | 제품명 (예: "타이레놀") |
| `ingredientKo` | 성분명 (예: "아세트아미노펜") |
| `rxOtc` | "OTC" / "RX" |
| `indicationsSummary` | 적응증 요약 (선택) |
| `warningsSummary` | 주의사항 요약 (선택) |

`ChatbotQuestionRequestDto` 에 `@Valid MedicineContextDto medicineContext` 필드 추가 (optional, `@Size` 제약).
기존 요청(컨텍스트 없음) 은 그대로 동작 — **backward compatible**.

### 2. 챗봇 프롬프트 빌더 도입 (`f727758`)

`ChatbotPromptBuilder` — 컨텍스트 유·무에 따라 메시지 리스트 빌드:

- **컨텍스트 없음 / 모든 필드 blank** → user 메시지만 (기존 동작)
- **컨텍스트 있음** → system 메시지 + user 메시지

시스템 프롬프트 골격:
```
당신은 한국 사용자에게 의약품 정보를 설명하는 보조 챗봇입니다.
현재 대화는 아래 약에 대한 질문이므로, 이 약의 범위를 벗어난 일반론으로 빗나가지 마세요.
불확실하거나 안전에 영향이 있는 사안은 반드시 '의사·약사와 상담'을 안내하고,
처방 변경을 단독으로 지시하지 마세요.

약 컨텍스트:
- 제품명: ...
- 성분: ...
- 구분: ...
- 적응증 요약: ...
- 주의사항 요약: ...
```

`ChatbotServiceImpl` 이 이 빌더에 위임하도록 리팩터.

### 3. 평가 Version B 러너 추가 (`75ba114`)

`eval/chatbot-rag/runners/version_b_anchoring.py` — 같은 모델(`gpt-3.5-turbo`) 에 골든셋 `drug` 필드를 system 프롬프트로 주입. `run_eval.py --version B` 로 실행.

순수 **"앵커링 효과"** 분리 측정이 목적 — Version C(RAG) 와 대비해 앵커링만으로 얼마가 개선되고 RAG 가 추가로 얼마를 끌어올리는지 구분.

## 응답 계약

외부 응답 스키마 변경 없음. `ChatbotResponseDto` 동일.
요청 스키마는 **필드 추가만** (optional) 이라 기존 클라이언트 호환.

## 검증

### 단위 테스트 (신규 7건)

`ChatbotPromptBuilderTest`:
- 컨텍스트가 없으면 user 메시지만 포함한다
- 모든 필드가 null 이면 user 메시지만 포함한다
- 공백만 있는 필드는 무시된다
- 컨텍스트가 있으면 system 메시지가 앞에 붙는다
- 시스템 프롬프트에 제공된 필드만 포함된다
- 시스템 프롬프트에 안전 가드레일 문구가 포함된다
- 모든 메타데이터 필드가 순서대로 포함된다

### 전체 테스트 통과

```
./gradlew :common:test :api:test :app:test → BUILD SUCCESSFUL
```

### 평가 러너 드라이런 통과

```
python eval/chatbot-rag/run_eval.py --version B --dry-run --limit 5
→ 리포트(JSON + MD) 정상 생성
```

## 후속 작업 (별도 이슈/PR)

- [ ] `OPENAI_API_KEY` + `ANTHROPIC_API_KEY` 세팅 후 Version A / B 실측정 (82문항)
- [ ] A vs B 비교 리포트 — keyword recall / judge accuracy·completeness·helpfulness / hallucination rate / p95 latency / 토큰 비용
- [ ] 골든셋 라벨 검증 자동화 (FDA openFDA 호출)
- [ ] Version C (RAG: pgvector + 라벨 청크 임베딩) 구현

## 🔗 관련 이슈

closes #54