### PR TITLE
[REFACTOR] 평가 LLM-judge를 OpenAI(gpt-4o)로 전환 (#56)

### DIFF
--- a/eval/chatbot-rag/.env.example
+++ b/eval/chatbot-rag/.env.example
@@ -1,0 +1,9 @@
+# 평가 스크립트 실행에 필요한 환경변수 템플릿입니다.
+# `cp .env.example .env` 로 복사한 뒤 실제 키를 채워 넣으세요.
+# `.env` 는 gitignore 에 포함되어 있습니다.
+
+OPENAI_API_KEY=
+
+# 선택 — 기본값 오버라이드
+# CHATBOT_MODEL=gpt-3.5-turbo
+# JUDGE_MODEL=gpt-4o

--- a/eval/chatbot-rag/config.py
+++ b/eval/chatbot-rag/config.py
@@ -18,10 +18,9 @@ GOLDENSET_FILES = [
 RESULTS_DIR = ROOT / "results"
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 
 CHATBOT_MODEL = os.getenv("CHATBOT_MODEL", "gpt-3.5-turbo")
-JUDGE_MODEL = os.getenv("JUDGE_MODEL", "claude-sonnet-4-6")
+JUDGE_MODEL = os.getenv("JUDGE_MODEL", "gpt-4o")
 
 CHATBOT_TIMEOUT = 30
 JUDGE_TIMEOUT = 60

--- a/eval/chatbot-rag/evaluators/llm_judge.py
+++ b/eval/chatbot-rag/evaluators/llm_judge.py
@@ -1,11 +1,12 @@
-"""LLM-as-judge — Claude Sonnet 으로 정확도/완전성/유용성 1-5 점.
+"""LLM-as-judge — OpenAI gpt-4o 로 정확도/완전성/유용성 1-5 점.
 
-생성기(gpt-3.5-turbo)와 다른 모델을 써서 self-preference bias 를 줄임.
+생성기(gpt-3.5-turbo) 보다 상위 모델을 써서 self-preference bias 를 간접적으로 완화.
+동일 모델 패밀리라는 한계는 있으나, A/B/C 상대 비교 목적에는 충분.
 """
 import json
 import re
 
-from config import ANTHROPIC_API_KEY, JUDGE_MODEL, JUDGE_TIMEOUT
+from config import JUDGE_MODEL, JUDGE_TIMEOUT, OPENAI_API_KEY
 
 _SYSTEM = """\
 당신은 한국 의약품 정보에 대한 챗봇 답변을 평가하는 심사관입니다.
@@ -31,18 +32,19 @@ _SYSTEM = """\
 
 
 def judge(item: dict, answer: str) -> dict:
-    if not ANTHROPIC_API_KEY:
-        raise RuntimeError("ANTHROPIC_API_KEY not set — set env var or use --dry-run")
-    from anthropic import Anthropic  # lazy import
-    client = Anthropic(api_key=ANTHROPIC_API_KEY, timeout=JUDGE_TIMEOUT)
-    prompt = _build_prompt(item, answer)
-    resp = client.messages.create(
+    if not OPENAI_API_KEY:
+        raise RuntimeError("OPENAI_API_KEY not set — set env var or use --dry-run")
+    from openai import OpenAI  # lazy import
+    client = OpenAI(api_key=OPENAI_API_KEY, timeout=JUDGE_TIMEOUT)
+    resp = client.chat.completions.create(
         model=JUDGE_MODEL,
-        max_tokens=512,
-        system=_SYSTEM,
-        messages=[{"role": "user", "content": prompt}],
+        messages=[
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": _build_prompt(item, answer)},
+        ],
+        response_format={"type": "json_object"},
     )
-    raw = resp.content[0].text if resp.content else ""
+    raw = resp.choices[0].message.content or ""
     return _parse(raw)
 
 

--- a/eval/chatbot-rag/requirements.txt
+++ b/eval/chatbot-rag/requirements.txt
@@ -1,3 +1,2 @@
 openai>=1.30.0
-anthropic>=0.40.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## 📌 개요

PR #53 에서 생성기(`gpt-3.5-turbo`) 와 다른 모델 패밀리를 써서 self-preference bias 를 완화하려는 의도로 평가 하네스의 LLM-judge 를 Claude Sonnet 으로 구현했습니다.
다만 팀이 Anthropic API 를 운영상 사용하지 않으므로 OpenAI 하나로 단일화합니다. 이를 통해 운영·비용 관리가 단순해지며, 측정 실행에 추가 가입·결제 단계가 필요 없어집니다.

## 🎯 변경 내역 (`f04d396`)

### 1. LLM-judge 를 OpenAI gpt-4o 로 재구현

- Anthropic SDK 제거 후 OpenAI Chat Completion API 로 재작성 (`evaluators/llm_judge.py`)
- 응답 포맷을 `response_format={"type": "json_object"}` 로 강제해 파싱 안정성을 확보
- system 프롬프트와 평가 축(accuracy / completeness / helpfulness 1–5 + hallucination flag) 은 그대로 유지
- 생성기(`gpt-3.5-turbo`) 보다 상위 모델을 써서 간접적인 bias 완화

### 2. 설정·의존성 단순화

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| `config.py` 환경변수 | `OPENAI_API_KEY` + `ANTHROPIC_API_KEY` | `OPENAI_API_KEY` 만 |
| `JUDGE_MODEL` 기본값 | `claude-sonnet-4-6` | `gpt-4o` |
| `requirements.txt` | `openai`, `anthropic`, `python-dotenv` | `openai`, `python-dotenv` |
| `.env.example` (신규) | — | `OPENAI_API_KEY` 하나만 노출 |

## 응답 계약

외부 응답 스키마 변경 없음. 평가 결과 JSON/Markdown 포맷(`results/*.{json,md}`) 동일. 평가 점수 축(accuracy/completeness/helpfulness/hallucination_flag) 도 그대로 유지됩니다.


## 검증

### 드라이런 통과

```bash
python eval/chatbot-rag/run_eval.py --version A --dry-run --limit 3
python eval/chatbot-rag/run_eval.py --version B --dry-run --limit 3
```

두 케이스 모두 에러 없이 완주하며 리포트(JSON + MD) 가 정상적으로 생성되는 것을 확인했습니다.

### 정적 확인

- `config.py` 에서 `ANTHROPIC_API_KEY` 참조가 제거됨
- `evaluators/llm_judge.py` 에서 `from anthropic import ...` 구문이 제거됨
- `requirements.txt` 에 `anthropic` 항목이 남아있지 않음

## 🔗 관련 이슈

closes #56