### PR TITLE
[FEAT] Chatbot RAG 프로덕션 통합 - /retrieve 연동 + 앵커링 폴백 (C-6)

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/chatbot/external/RagApiConfig.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/external/RagApiConfig.java
@@ -1,0 +1,13 @@
+package com.mediforme.mediforme.chatbot.external;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class RagApiConfig {     // Chatbot RAG 검색 서비스 (mediforme-chatbot-rag)
+
+    @Value("${api.rag.base-url}")
+    private String baseUrl;
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/external/adapter/HttpRagClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/external/adapter/HttpRagClient.java
@@ -1,0 +1,90 @@
+package com.mediforme.mediforme.chatbot.external.adapter;
+
+import com.mediforme.mediforme.chatbot.external.RagApiConfig;
+import com.mediforme.mediforme.chatbot.external.port.ChatbotRagClient;
+import com.mediforme.mediforme.chatbot.external.port.RagChunk;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * mediforme-chatbot-rag /retrieve 호출 어댑터
+ *
+ * 검색 서비스 장애·빈 결과는 빈 리스트로 흡수해, 호출부가 앵커링으로 폴백하도록 한다.
+ */
+@Slf4j
+@Component
+public class HttpRagClient implements ChatbotRagClient {
+
+    private final RestClient restClient;
+
+    public HttpRagClient(RagApiConfig config) {
+        this.restClient = RestClient.builder()
+                .baseUrl(config.getBaseUrl())
+                .build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<RagChunk> retrieve(String query, String drugId, int topK) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("query", query);
+        if (drugId != null && !drugId.isBlank()) {
+            body.put("drug_id", drugId);
+        }
+        body.put("top_k", topK);
+
+        try {
+            Map<String, Object> response = restClient.post()
+                    .uri("/retrieve")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response == null) {
+                return List.of();
+            }
+            Object chunks = response.get("chunks");
+            if (!(chunks instanceof List<?> list)) {
+                return List.of();
+            }
+
+            List<RagChunk> out = new ArrayList<>();
+            for (Object c : list) {
+                if (c instanceof Map<?, ?> m) {
+                    out.add(new RagChunk(
+                            str(m.get("text")),
+                            str(m.get("drug_name")),
+                            str(m.get("section")),
+                            str(m.get("source")),
+                            dbl(m.get("similarity"))
+                    ));
+                }
+            }
+            return out;
+
+        } catch (Exception e) {
+            log.warn("RAG /retrieve 호출 실패, 앵커링으로 폴백합니다: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private static String str(Object v) {
+        return v == null ? "" : v.toString();
+    }
+
+    private static double dbl(Object v) {
+        return v instanceof Number n ? n.doubleValue() : 0.0;
+    }
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/external/port/ChatbotRagClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/external/port/ChatbotRagClient.java
@@ -1,0 +1,22 @@
+package com.mediforme.mediforme.chatbot.external.port;
+
+import java.util.List;
+
+/**
+ * Chatbot RAG 검색 포트
+ *
+ * 사용자 질문과 약 식별자로 의약품 라벨 청크를 검색한다.
+ * 구현은 mediforme-chatbot-rag 의 /retrieve 를 호출한다.
+ */
+public interface ChatbotRagClient {
+
+    /**
+     * 질문·약 식별자로 라벨 청크 top-k 검색
+     *
+     * @param query  사용자 자연어 질문
+     * @param drugId 약 식별자(성분/이름). null/blank 면 필터 없이 검색
+     * @param topK   최대 청크 수
+     * @return 검색된 청크 리스트. 실패·빈 결과는 빈 리스트(호출부가 앵커링으로 폴백)
+     */
+    List<RagChunk> retrieve(String query, String drugId, int topK);
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/external/port/RagChunk.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/external/port/RagChunk.java
@@ -1,0 +1,13 @@
+package com.mediforme.mediforme.chatbot.external.port;
+
+/**
+ * RAG 검색으로 받은 라벨 청크 1건
+ */
+public record RagChunk(
+        String text,
+        String drugName,
+        String section,
+        String source,
+        double similarity
+) {
+}

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilder.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilder.java
@@ -2,6 +2,7 @@ package com.mediforme.mediforme.chatbot.service;
 
 import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto.Message;
 import com.mediforme.mediforme.chatbot.dto.MedicineContextDto;
+import com.mediforme.mediforme.chatbot.external.port.RagChunk;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,13 @@ public final class ChatbotPromptBuilder {
                     + "처방 변경을 단독으로 지시하지 마세요.\n\n"
                     + "약 컨텍스트:";
 
+    private static final String RAG_PROMPT_HEADER =
+            "당신은 한국 사용자에게 의약품 정보를 설명하는 보조 챗봇입니다.\n"
+                    + "현재 대화는 아래 약에 대한 질문이므로, 이 약의 범위를 벗어난 일반론으로 빗나가지 마세요.\n"
+                    + "불확실하거나 안전에 영향이 있는 사안은 반드시 '의사·약사와 상담'을 안내하고, "
+                    + "처방 변경을 단독으로 지시하지 마세요.\n\n"
+                    + "아래 [검색된 라벨 컨텍스트] 에 근거해 답하고, 컨텍스트에 없는 내용은 추측하지 마세요.";
+
     private ChatbotPromptBuilder() {
     }
 
@@ -25,6 +33,33 @@ public final class ChatbotPromptBuilder {
         }
         messages.add(new Message("user", question));
         return messages;
+    }
+
+    /**
+     * RAG 검색 청크를 컨텍스트로 주입한 메시지 구성
+     * 청크가 비어 있으면 호출부가 build(앵커링) 로 폴백하므로 여기선 청크가 있다고 가정
+     */
+    public static List<Message> buildRag(String question, MedicineContextDto ctx, List<RagChunk> chunks) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(new Message("system", buildRagSystemContent(ctx, chunks)));
+        messages.add(new Message("user", question));
+        return messages;
+    }
+
+    static String buildRagSystemContent(MedicineContextDto ctx, List<RagChunk> chunks) {
+        StringBuilder sb = new StringBuilder(RAG_PROMPT_HEADER);
+        if (ctx != null) {
+            appendIfPresent(sb, "제품명", ctx.getNameKo());
+            appendIfPresent(sb, "성분", ctx.getIngredientKo());
+        }
+        sb.append("\n\n[검색된 라벨 컨텍스트]");
+        int i = 1;
+        for (RagChunk c : chunks) {
+            sb.append('\n').append(i++).append(". [")
+                    .append(c.drugName()).append(" / ").append(c.section()).append("]\n")
+                    .append(c.text());
+        }
+        return sb.toString();
     }
 
     static String buildSystemContent(MedicineContextDto ctx) {

--- a/api/src/main/java/com/mediforme/mediforme/chatbot/service/impl/ChatbotServiceImpl.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/service/impl/ChatbotServiceImpl.java
@@ -4,6 +4,9 @@ import com.mediforme.mediforme.chatbot.external.OpenAIConfig;
 import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto;
 import com.mediforme.mediforme.chatbot.dto.ChatbotQuestionRequestDto;
 import com.mediforme.mediforme.chatbot.dto.ChatbotResponseDto;
+import com.mediforme.mediforme.chatbot.dto.MedicineContextDto;
+import com.mediforme.mediforme.chatbot.external.port.ChatbotRagClient;
+import com.mediforme.mediforme.chatbot.external.port.RagChunk;
 import com.mediforme.mediforme.chatbot.service.ChatbotPromptBuilder;
 import com.mediforme.mediforme.chatbot.service.ChatbotService;
 import org.springframework.http.HttpEntity;
@@ -13,10 +16,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 @Service
 public class ChatbotServiceImpl implements ChatbotService {
 
     private static final RestTemplate restTemplate = new RestTemplate();
+    private static final int RAG_TOP_K = 5;
+
+    private final ChatbotRagClient ragClient;
+
+    public ChatbotServiceImpl(ChatbotRagClient ragClient) {
+        this.ragClient = ragClient;
+    }
 
     private HttpEntity<ChatbotRequestDto> buildHttpEntity(ChatbotRequestDto requestDto) {
         HttpHeaders headers = new HttpHeaders();
@@ -36,10 +48,37 @@ public class ChatbotServiceImpl implements ChatbotService {
 
     @Override
     public ChatbotResponseDto askQuestion(ChatbotQuestionRequestDto requestDto) {
-        ChatbotRequestDto chatGptRequestDto = new ChatbotRequestDto(
-                OpenAIConfig.MODEL,
-                ChatbotPromptBuilder.build(requestDto.getQuestion(), requestDto.getMedicineContext())
-        );
+        MedicineContextDto ctx = requestDto.getMedicineContext();
+        List<RagChunk> chunks = ragClient.retrieve(
+                requestDto.getQuestion(), resolveDrugId(ctx), RAG_TOP_K);
+
+        // 검색 청크가 있으면 RAG 컨텍스트로, 없으면(미커버·장애) 기존 앵커링으로 폴백
+        List<ChatbotRequestDto.Message> messages = chunks.isEmpty()
+                ? ChatbotPromptBuilder.build(requestDto.getQuestion(), ctx)
+                : ChatbotPromptBuilder.buildRag(requestDto.getQuestion(), ctx, chunks);
+
+        ChatbotRequestDto chatGptRequestDto = new ChatbotRequestDto(OpenAIConfig.MODEL, messages);
         return this.getResponse(this.buildHttpEntity(chatGptRequestDto));
+    }
+
+    /**
+     * /retrieve 의 drug_id 로 쓸 약 식별자 결정
+     * 한국어 성분명을 우선하고, 없으면 제품명 사용 (없으면 null → 필터 없이 검색)
+     */
+    private static String resolveDrugId(MedicineContextDto ctx) {
+        if (ctx == null) {
+            return null;
+        }
+        if (isPresent(ctx.getIngredientKo())) {
+            return ctx.getIngredientKo();
+        }
+        if (isPresent(ctx.getNameKo())) {
+            return ctx.getNameKo();
+        }
+        return null;
+    }
+
+    private static boolean isPresent(String v) {
+        return v != null && !v.isBlank();
     }
 }

--- a/api/src/test/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilderTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/chatbot/service/ChatbotPromptBuilderTest.java
@@ -2,6 +2,7 @@ package com.mediforme.mediforme.chatbot.service;
 
 import com.mediforme.mediforme.chatbot.dto.ChatbotRequestDto.Message;
 import com.mediforme.mediforme.chatbot.dto.MedicineContextDto;
+import com.mediforme.mediforme.chatbot.external.port.RagChunk;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -108,5 +109,40 @@ class ChatbotPromptBuilderTest {
         assertThat(rxIdx).isGreaterThan(ingredientIdx);
         assertThat(indIdx).isGreaterThan(rxIdx);
         assertThat(warnIdx).isGreaterThan(indIdx);
+    }
+
+    @Test
+    void RAG_시스템_프롬프트에_검색_청크가_포함된다() {
+        MedicineContextDto ctx = MedicineContextDto.builder()
+                .nameKo("타이레놀")
+                .ingredientKo("아세트아미노펜")
+                .build();
+        List<RagChunk> chunks = List.of(
+                new RagChunk("간 손상 위험이 있으므로 음주 시 주의", "Pain Reliever", "warnings", "fda_label", 0.9),
+                new RagChunk("두통·발열 완화에 사용", "Pain Reliever", "indications_and_usage", "fda_label", 0.8)
+        );
+
+        String sys = ChatbotPromptBuilder.buildRagSystemContent(ctx, chunks);
+
+        assertThat(sys).contains("[검색된 라벨 컨텍스트]");
+        assertThat(sys).contains("간 손상 위험");
+        assertThat(sys).contains("두통·발열 완화");
+        assertThat(sys).contains("의사·약사와 상담");
+        assertThat(sys).contains("추측하지 마세요");
+    }
+
+    @Test
+    void RAG_메시지는_system_과_user_로_구성된다() {
+        List<RagChunk> chunks = List.of(
+                new RagChunk("부작용 정보", "WEGOVY", "adverse_reactions", "fda_label", 0.7)
+        );
+
+        List<Message> messages = ChatbotPromptBuilder.buildRag("부작용 뭐 있어?", null, chunks);
+
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getRole()).isEqualTo("system");
+        assertThat(messages.get(0).getContent()).contains("부작용 정보");
+        assertThat(messages.get(1).getRole()).isEqualTo("user");
+        assertThat(messages.get(1).getContent()).isEqualTo("부작용 뭐 있어?");
     }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -38,6 +38,8 @@ api:
     base-url: "https://api.fda.gov"
   rxnorm:
     base-url: "https://rxnav.nlm.nih.gov/REST"
+  rag:  # Chatbot RAG 검색 서비스 (mediforme-chatbot-rag)
+    base-url: ${RAG_SERVICE_URL:http://localhost:8000}
 
 
 


### PR DESCRIPTION
closes #64

## 변경

측정(#61/#63)으로 검증한 RAG 를 실제 프로덕션 챗봇에 연결합니다. 지금까지 챗봇은 호출자 주입 `medicineContext`(앵커링)만 썼는데, 이제 검색 서비스(mediforme-chatbot-rag `/retrieve`)에서 실제 라벨 청크를 받아 컨텍스트로 주입합니다.

- `chatbot/external/port/ChatbotRagClient` + `RagChunk` — RAG 검색 포트
- `chatbot/external/adapter/HttpRagClient` — `/retrieve` RestClient 호출. 장애·빈 결과는 빈 리스트로 흡수
- `chatbot/external/RagApiConfig` + `application.yml` `api.rag.base-url` (`${RAG_SERVICE_URL:http://localhost:8000}`)
- `ChatbotPromptBuilder.buildRag()` — 검색 청크 컨텍스트 + 안전 가드레일 시스템 프롬프트
- `ChatbotServiceImpl` — 질문+drug_id 로 검색 → 청크 있으면 RAG, 없으면 **기존 앵커링으로 폴백**

## 핵심: 회귀 없는 점진 도입

검색이 비거나 실패하면 기존 앵커링 프롬프트로 그대로 폴백하므로, 어떤 경우에도 현재 동작 이하로 떨어지지 않습니다.

## drug_id 전략 (v1)

요청에 영어 generic 이 없어 `ingredientKo`→`nameKo` 를 drug_id 로 사용합니다. MFDS(한국어) 라벨 위주 커버이며, FDA(영어) 커버리지 확대는 후속 KO→EN 매핑 과제입니다.

## 검증

`./gradlew :api:test` 통과(ChatbotPromptBuilder RAG 경로 단위 테스트 추가), `:app:compileJava` 성공.

## 남은 일 (별도)

- 검색 서비스 배포 + `RAG_SERVICE_URL` 운영값 설정
- KO→EN 약 식별자 매핑(FDA 커버리지 확대)
- 선행 측정 근거: A/B/C 리포트(#63), 검색 scoped retrieval(mediforme-chatbot-rag PR #38)