### PR TITLE
[FIX] HttpRagClient HTTP/1.1 강제 — RAG /retrieve 422 해결

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/chatbot/external/adapter/HttpRagClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/chatbot/external/adapter/HttpRagClient.java
@@ -5,6 +5,7 @@ import com.mediforme.mediforme.chatbot.external.port.ChatbotRagClient;
 import com.mediforme.mediforme.chatbot.external.port.RagChunk;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -25,8 +26,11 @@ public class HttpRagClient implements ChatbotRagClient {
     private final RestClient restClient;
 
     public HttpRagClient(RagApiConfig config) {
+        // 기본 요청 팩토리(JDK HttpClient)는 HTTP/2 협상을 시도해 uvicorn(HTTP/1.1) 대상
+        // POST 가 깨진다(빈 body → 422). HTTP/1.1 전용 팩토리로 고정한다.
         this.restClient = RestClient.builder()
                 .baseUrl(config.getBaseUrl())
+                .requestFactory(new SimpleClientHttpRequestFactory())
                 .build();
     }
 


### PR DESCRIPTION
closes #69

## 문제

C-6(#65)의 `HttpRagClient` 가 `RestClient.builder().build()` 기본 요청 팩토리(JDK HttpClient, HTTP/2 협상)를 써서, uvicorn(HTTP/1.1) RAG 서비스로의 POST 가 프로토콜 불일치로 깨졌습니다. FastAPI 가 빈 body 로 받아 항상 422 → `HttpRagClient` 가 예외를 빈 리스트로 흡수 → 챗봇은 **항상 앵커링 폴백**. 즉 RAG 가 실제론 동작하지 않았습니다.

## 고침

`HttpRagClient` 의 RestClient 에 `SimpleClientHttpRequestFactory`(HTTP/1.1) 지정.

## 검증 (로컬, 떠 있는 RAG 컨테이너 대상)

- 수정 전: 동일 요청이 422(빈 body). curl 로는 200 → 클라이언트 transport 문제 확인.
- 수정 후: 실제 `HttpRagClient.retrieve("아세트아미노펜 부작용","acetaminophen",5)` → 5청크 정상 반환(Pain Reliever Extra Strength 등).

end-to-end(컨테이너 기동 후 JVM 에서 실제 호출)로 확인했습니다. GET 외부 클라이언트(FDA·RxNorm)는 HTTP/2 지원 서버라 영향 없습니다.