### PR TITLE
[FIX] DUR 병용금기 매핑 보정 (라이브 검증 반영)

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
@@ -38,10 +38,11 @@ public class DurInteractionRuleAdapter implements InteractionRulePort {
             Set<String> contraindicated = new LinkedHashSet<>();
             for (Object o : items) {
                 if (!(o instanceof JSONObject it)) continue;
-                // 병용금기 상대 약/성분명 (명세 버전에 따라 필드명이 달라질 수 있어 방어적으로 추출)
+                // 병용금기 상대 성분명 우선 (같은 성분의 제품이 여러 개라 성분 기준이 간결).
+                // 성분명이 없으면 품목명 → 영문 성분명 순으로 fallback
                 String mix = MfdsMedicineClient.firstNonBlank(
-                    MfdsMedicineClient.getString(it, "MIXTURE_ITEM_NAME"),
                     MfdsMedicineClient.getString(it, "MIXTURE_INGR_KOR_NAME"),
+                    MfdsMedicineClient.getString(it, "MIXTURE_ITEM_NAME"),
                     MfdsMedicineClient.getString(it, "MIXTURE_INGR_ENG_NAME")
                 );
                 if (mix != null && !mix.isBlank()) {

--- a/api/src/main/java/com/mediforme/mediforme/medicine/external/client/DurInteractionClient.java
+++ b/api/src/main/java/com/mediforme/mediforme/medicine/external/client/DurInteractionClient.java
@@ -29,7 +29,8 @@ import java.nio.charset.StandardCharsets;
 public class DurInteractionClient {
 
     private static final int CONNECT_TIMEOUT_MS = 2000;
-    private static final int READ_TIMEOUT_MS = 3000;
+    // 병용금기가 많은 약(예: 와파린)은 응답이 커서 여유 있는 read timeout 필요
+    private static final int READ_TIMEOUT_MS = 6000;
     private static final int DEFAULT_PAGE_NO = 1;
     private static final int DEFAULT_NUM_OF_ROWS = 100;
 

--- a/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
@@ -19,8 +19,8 @@ class DurInteractionRuleAdapterTest {
     void DUR_병용금기를_경고_문자열로_매핑한다() throws Exception {
         DurInteractionClient client = mock(DurInteractionClient.class);
         JSONArray items = new JSONArray();
-        items.add(item("와파린정"));
-        items.add(item("아스피린장용정"));
+        items.add(item("메토트렉세이트"));
+        items.add(item("케토롤락트로메타민"));
         when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
 
         DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
@@ -29,8 +29,8 @@ class DurInteractionRuleAdapterTest {
         assertThat(rules).hasSize(1);
         assertThat(rules.get(0).getName()).isEqualTo("이부프로펜");
         assertThat(rules.get(0).getInteractionWarnings())
-            .contains("와파린정")
-            .contains("아스피린장용정");
+            .contains("메토트렉세이트")
+            .contains("케토롤락트로메타민");
     }
 
     @Test
@@ -54,9 +54,9 @@ class DurInteractionRuleAdapterTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static JSONObject item(String mixtureItemName) {
+    private static JSONObject item(String mixtureIngrKorName) {
         JSONObject o = new JSONObject();
-        o.put("MIXTURE_ITEM_NAME", mixtureItemName);
+        o.put("MIXTURE_INGR_KOR_NAME", mixtureIngrKorName);
         return o;
     }
 }


### PR DESCRIPTION
실제 DUR API 키로 라이브 검증을 진행하면서 발견한 점들을 반영했습니다.

## 변경

- 응답에는 상대 품목명(`MIXTURE_ITEM_NAME`)과 상대 성분명(`MIXTURE_INGR_KOR_NAME`)이 모두 들어 있습니다. 같은 성분이라도 제품이 여러 개라 품목 기준으로 모으면 경고가 장황해지기 때문에, 성분명을 우선해서 매핑하도록 바꿨습니다. 그 결과 경고가 더 간결하고 정확하게 나옵니다.
- 와파린처럼 병용금기가 많은 약은 응답이 커서 read timeout 3초로는 자주 시간이 초과되어 빈 결과가 나왔습니다. 그래서 read timeout 을 6초로 늘렸습니다.
- 단위 테스트도 실제 응답 필드인 `MIXTURE_INGR_KOR_NAME` 에 맞게 고쳤습니다.

## 라이브 검증 결과 (실제 키)

실제 DUR API 키로 직접 호출해 확인했습니다.

- 부루펜은 메토트렉세이트, 케토롤락트로메타민과 병용금기로 나옵니다.
- 심바스타틴은 이트라코나졸과 병용금기로 나옵니다.
- Java HttpURLConnection 으로 정상 호출되며, 기존 e약은요 연동과 동일한 패턴입니다.

PR #72 의 후속 작업입니다.