### PR TITLE
[FEAT] 성분 충돌 검사 — 성분(component) 기준 매칭

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
@@ -29,10 +29,22 @@ public class DurInteractionRuleAdapter implements InteractionRulePort {
 
     @Override
     public List<MedicineInteractResponseDto> lookupByMedicineName(String medicineName) {
+        Set<String> contraindicated = lookupContraindicatedIngredients(medicineName);
+        if (contraindicated.isEmpty()) {
+            return List.of();
+        }
+        return List.of(MedicineInteractResponseDto.builder()
+            .name(medicineName)
+            .interactionWarnings(String.join(", ", contraindicated))
+            .build());
+    }
+
+    @Override
+    public Set<String> lookupContraindicatedIngredients(String medicineName) {
         try {
             JSONArray items = client.fetchUsjntTabooByName(medicineName);
             if (items == null || items.isEmpty()) {
-                return List.of();
+                return Set.of();
             }
 
             Set<String> contraindicated = new LinkedHashSet<>();
@@ -49,19 +61,11 @@ public class DurInteractionRuleAdapter implements InteractionRulePort {
                     contraindicated.add(mix);
                 }
             }
-
-            if (contraindicated.isEmpty()) {
-                return List.of();
-            }
-
-            return List.of(MedicineInteractResponseDto.builder()
-                .name(medicineName)
-                .interactionWarnings(String.join(", ", contraindicated))
-                .build());
+            return contraindicated;
 
         } catch (Exception e) {
             log.warn("DUR 병용금기 조회 실패 medicineName={}: {}", medicineName, e.getMessage());
-            return List.of();
+            return Set.of();
         }
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/check/engine/InteractionEngine.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/engine/InteractionEngine.java
@@ -1,16 +1,20 @@
 package com.mediforme.mediforme.check.engine;
 
 import com.mediforme.mediforme.check.port.InteractionRulePort;
-import com.mediforme.mediforme.medicine.dto.MedicineInteractResponseDto;
 import com.mediforme.mediforme.medicine.dto.MedicineInteractionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 약물 상호작용 계산 엔진
+ *
+ * 새 복용 예정 약의 병용금기 성분 집합을 한 번 조회한 뒤, 기존 복용 약의 성분(component)과
+ * 정규화 비교한다. 이름이 아닌 성분 기준으로 매칭해 제품명·브랜드·용량 표기 차이를 흡수한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,23 +26,43 @@ public class InteractionEngine {
      * 사용자의 복용 약 목록과 새 복용 예정 약을 비교해 충돌 경고 메시지 리스트를 반환
      */
     public List<String> evaluate(List<MedicineInteractionDto> userMeds, String newMedication) {
-        List<String> warnings = new ArrayList<>();
-
-        for (MedicineInteractionDto userMed : userMeds) {
-            List<MedicineInteractResponseDto> rules = rulePort.lookupByMedicineName(userMed.getMedicineName());
-
-            for (MedicineInteractResponseDto rule : rules) {
-                if (rule.getInteractionWarnings() != null
-                    && rule.getInteractionWarnings().contains(newMedication)) {
-                    warnings.add(String.format(
-                        "%s과(와) %s는 함께 복용하면 안 됩니다! (주의: %s)",
-                        userMed.getMedicineName(),
-                        newMedication,
-                        rule.getInteractionWarnings()));
-                }
-            }
+        if (userMeds == null || userMeds.isEmpty()) {
+            return List.of();
         }
 
+        Set<String> contraindicated = rulePort.lookupContraindicatedIngredients(newMedication).stream()
+            .map(InteractionEngine::normalize)
+            .filter(s -> !s.isBlank())
+            .collect(Collectors.toSet());
+        if (contraindicated.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> warnings = new ArrayList<>();
+        for (MedicineInteractionDto userMed : userMeds) {
+            // 기존 약은 성분(component)을 우선 사용, 없으면 약 이름으로 대체
+            String candidate = hasText(userMed.getComponent())
+                ? userMed.getComponent() : userMed.getMedicineName();
+            if (!hasText(candidate)) {
+                continue;
+            }
+            String norm = normalize(candidate);
+            boolean conflict = contraindicated.stream()
+                .anyMatch(c -> norm.contains(c) || c.contains(norm));
+            if (conflict) {
+                warnings.add(String.format(
+                    "%s과(와) %s는 병용금기입니다. 함께 복용 전 의사·약사와 상담하세요.",
+                    userMed.getMedicineName(), newMedication));
+            }
+        }
         return warnings;
+    }
+
+    private static String normalize(String s) {
+        return s == null ? "" : s.toLowerCase().replaceAll("\\s+", "");
+    }
+
+    private static boolean hasText(String s) {
+        return s != null && !s.isBlank();
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/check/port/InteractionRulePort.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/port/InteractionRulePort.java
@@ -3,6 +3,7 @@ package com.mediforme.mediforme.check.port;
 import com.mediforme.mediforme.medicine.dto.MedicineInteractResponseDto;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * 약 이름을 기반 해당 약의 상호작용 규칙/경고 조회 포트
@@ -10,7 +11,12 @@ import java.util.List;
 public interface InteractionRulePort {
 
     /**
-     * 주어진 약 이름에 대한 상호작용 규칙 조회
+     * 주어진 약 이름에 대한 상호작용 규칙 조회 (/info 표시용)
      */
     List<MedicineInteractResponseDto> lookupByMedicineName(String medicineName);
+
+    /**
+     * 주어진 약과 병용금기인 상대 성분명 집합 조회 (성분 충돌 검사용)
+     */
+    Set<String> lookupContraindicatedIngredients(String medicineName);
 }

--- a/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -51,6 +52,30 @@ class DurInteractionRuleAdapterTest {
         DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
 
         assertThat(adapter.lookupByMedicineName("이부프로펜")).isEmpty();
+    }
+
+    @Test
+    void 병용금기_상대_성분_집합을_반환한다() throws Exception {
+        DurInteractionClient client = mock(DurInteractionClient.class);
+        JSONArray items = new JSONArray();
+        items.add(item("메토트렉세이트"));
+        items.add(item("와파린"));
+        when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
+
+        DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
+        Set<String> contraindicated = adapter.lookupContraindicatedIngredients("이부프로펜");
+
+        assertThat(contraindicated).containsExactlyInAnyOrder("메토트렉세이트", "와파린");
+    }
+
+    @Test
+    void 예외시_성분_집합도_비어있다() throws Exception {
+        DurInteractionClient client = mock(DurInteractionClient.class);
+        when(client.fetchUsjntTabooByName(anyString())).thenThrow(new RuntimeException("network"));
+
+        DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
+
+        assertThat(adapter.lookupContraindicatedIngredients("이부프로펜")).isEmpty();
     }
 
     @SuppressWarnings("unchecked")

--- a/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
@@ -1,7 +1,6 @@
 package com.mediforme.mediforme.check.engine;
 
 import com.mediforme.mediforme.check.port.InteractionRulePort;
-import com.mediforme.mediforme.medicine.dto.MedicineInteractResponseDto;
 import com.mediforme.mediforme.medicine.dto.MedicineInteractionDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,86 +29,64 @@ class InteractionEngineTest {
     private InteractionEngine engine;
 
     @Test
-    @DisplayName("사용자 복용 약이 비어있으면 경고도 없고 규칙 조회도 하지 않는다")
+    @DisplayName("사용자 복용 약이 비어있으면 경고도 없고 조회도 하지 않는다")
     void evaluate_emptyUserMeds_returnsEmptyAndSkipsLookup() {
-        List<String> result = engine.evaluate(Collections.emptyList(), "아스피린");
+        List<String> result = engine.evaluate(Collections.emptyList(), "이부프로펜");
 
         assertThat(result).isEmpty();
-        verify(rulePort, never()).lookupByMedicineName(org.mockito.ArgumentMatchers.any());
+        verify(rulePort, never()).lookupContraindicatedIngredients(any());
     }
 
     @Test
-    @DisplayName("포트가 빈 규칙 리스트를 반환하면 경고 없음")
-    void evaluate_emptyRules_returnsEmpty() {
-        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
-            .userMedicineId(1L)
-            .medicineName("타이레놀")
-            .build();
-        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(Collections.emptyList());
+    @DisplayName("새 약의 병용금기 성분이 없으면 경고 없음")
+    void evaluate_noContraindication_returnsEmpty() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of());
+        MedicineInteractionDto med = MedicineInteractionDto.builder()
+            .medicineName("타이레놀").component("아세트아미노펜").build();
 
-        List<String> result = engine.evaluate(List.of(userMed), "아스피린");
-
-        assertThat(result).isEmpty();
+        assertThat(engine.evaluate(List.of(med), "이부프로펜")).isEmpty();
     }
 
     @Test
-    @DisplayName("interactionWarnings 에 새 약 이름이 포함되면 경고 메시지 생성")
-    void evaluate_warningContainsNewMedication_producesAlert() {
-        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
-            .userMedicineId(1L)
-            .medicineName("타이레놀")
-            .build();
-        MedicineInteractResponseDto rule = MedicineInteractResponseDto.builder()
-            .name("타이레놀")
-            .interactionWarnings("아세트아미노펜, 와파린")
-            .build();
-        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(rule));
+    @DisplayName("기존 약 성분이 새 약의 병용금기에 있으면 경고 생성")
+    void evaluate_componentInContraindicated_producesAlert() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
+            .willReturn(Set.of("메토트렉세이트", "와파린"));
+        MedicineInteractionDto med = MedicineInteractionDto.builder()
+            .medicineName("메토잘").component("메토트렉세이트").build();
 
-        List<String> result = engine.evaluate(List.of(userMed), "와파린");
+        List<String> result = engine.evaluate(List.of(med), "이부프로펜");
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0))
-            .contains("타이레놀")
-            .contains("와파린")
-            .contains("아세트아미노펜, 와파린");
+        assertThat(result.get(0)).contains("메토잘").contains("이부프로펜").contains("병용금기");
     }
 
     @Test
-    @DisplayName("여러 약 × 여러 규칙 조합에서 매칭된 건수만 정확히 반환")
-    void evaluate_multipleMedsAndRules_returnsOnlyMatchedCount() {
-        MedicineInteractionDto tylenol = MedicineInteractionDto.builder()
-            .userMedicineId(1L).medicineName("타이레놀").build();
-        MedicineInteractionDto ibuprofen = MedicineInteractionDto.builder()
-            .userMedicineId(2L).medicineName("이부프로펜").build();
+    @DisplayName("성분 표기 차이(용량·공백)는 정규화로 매칭")
+    void evaluate_normalizesComponent() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("메토트렉세이트"));
+        MedicineInteractionDto med = MedicineInteractionDto.builder()
+            .medicineName("메토잘정").component("메토트렉세이트 2.5mg").build();
 
-        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(
-            MedicineInteractResponseDto.builder()
-                .name("타이레놀").interactionWarnings("아스피린").build(),
-            MedicineInteractResponseDto.builder()
-                .name("타이레놀").interactionWarnings("와파린").build()      // 매칭 안됨
-        ));
-        given(rulePort.lookupByMedicineName("이부프로펜")).willReturn(List.of(
-            MedicineInteractResponseDto.builder()
-                .name("이부프로펜").interactionWarnings("아스피린, 와파린").build()
-        ));
-
-        List<String> result = engine.evaluate(List.of(tylenol, ibuprofen), "아스피린");
-
-        // 타이레놀 첫 규칙 1건 + 이부프로펜 규칙 1건 = 2건
-        assertThat(result).hasSize(2);
+        assertThat(engine.evaluate(List.of(med), "이부프로펜")).hasSize(1);
     }
 
     @Test
-    @DisplayName("interactionWarnings 가 null 인 규칙은 NPE 없이 스킵")
-    void evaluate_nullWarnings_skipsWithoutNpe() {
-        MedicineInteractionDto userMed = MedicineInteractionDto.builder()
-            .userMedicineId(1L).medicineName("타이레놀").build();
-        given(rulePort.lookupByMedicineName("타이레놀")).willReturn(List.of(
-            MedicineInteractResponseDto.builder().name("타이레놀").interactionWarnings(null).build()
-        ));
+    @DisplayName("충돌하지 않는 성분은 경고 없음")
+    void evaluate_noConflict_returnsEmpty() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("메토트렉세이트"));
+        MedicineInteractionDto med = MedicineInteractionDto.builder()
+            .medicineName("타이레놀").component("아세트아미노펜").build();
 
-        List<String> result = engine.evaluate(List.of(userMed), "와파린");
+        assertThat(engine.evaluate(List.of(med), "이부프로펜")).isEmpty();
+    }
 
-        assertThat(result).isEmpty();
+    @Test
+    @DisplayName("component 가 없으면 약 이름으로 매칭")
+    void evaluate_fallsBackToMedicineName() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("와파린"));
+        MedicineInteractionDto med = MedicineInteractionDto.builder().medicineName("와파린").build();
+
+        assertThat(engine.evaluate(List.of(med), "이부프로펜")).hasSize(1);
     }
 }


### PR DESCRIPTION
## 작업 개요

기존 `InteractionEngine` 이 새 약 이름을 기존약의 병용금기 문자열에 substring 으로 포함되는지만 보았기에, 새 약이 제품명·브랜드명으로 들어오면 DUR 의 성분명과 안 맞아 충돌을 놓칠 수 있었습니다. 이를 새 약의 병용금기 성분 집합과 기존약의 `component`(주요 성분)를 정규화 비교하는 성분 기준 매칭으로 재설계해 정확도와 일관성을 확보했습니다.

## 주요 변경 사항

#### 1. **InteractionRulePort 확장**

- `lookupContraindicatedIngredients(name) → Set<String>` 추가
- 기존 `lookupByMedicineName` 은 `/info` 표시 용도로 유지

#### 2. **InteractionEngine 재설계 (성분 기준)**

- 새 약의 병용금기 성분 집합을 한 번에 조회
- 기존약의 `component` 우선 사용, 없으면 `medicineName` 으로 폴백
- 소문자·공백 제거 정규화 + 양방향 contains 매칭으로 용량·표기 차이 흡수
- 경고 문구 일원화: `"%s과(와) %s는 병용금기입니다. 함께 복용 전 의사·약사와 상담하세요."`

#### 3. **DurInteractionRuleAdapter 보강**

- 성분 집합 반환 메서드 구현
- 기존 `/info` 매핑과 성분 추출 로직 공유 (LinkedHashSet)
- 호출 실패·결과 없음은 빈 결과로 흡수 (graceful)

#### 4. **테스트 갱신**

- `InteractionEngineTest`: 성분 기준 매칭·정규화(용량 표기)·`component` 폴백·충돌 없음 케이스
- `DurInteractionRuleAdapterTest`: `lookupContraindicatedIngredients` 케이스 추가
- `:api:test` · `:app:compileJava` 통과

## 라이브 검증

실제 DUR 키로 end-to-end 확인.

- 기존약: 메토잘정(component=메토트렉세이트), 타이레놀(component=아세트아미노펜)
- 새 약: `이부프로펜`
- 결과: 메토트렉세이트만 병용금기 경고, 아세트아미노펜은 경고 없음(정확)

## 고민사항

#### 1. **별도 한국어→영어 alias 사전을 두지 않은 이유**

검색(RAG) 서비스에서는 인덱스가 영어 라벨이라 한국어 drug_id 를 영어 generic 으로 매핑하는 alias 사전을 따로 두었습니다. 상호작용은 식약처 DUR 자체가 한국어 성분명(`MIXTURE_INGR_KOR_NAME`)을 제공하므로, 매핑 사전을 한 번 더 두기보다 DUR 응답을 그대로 비교 기준으로 삼는 편이 단일 출처 원칙에 맞다고 판단했습니다. 사전 중복·동기화 부담도 회피할 수 있습니다.

#### 2. **쿼리 방향 선택 (새 약 1회 조회 vs 기존약마다 조회)**

기존 설계는 기존약마다 DUR 을 조회한 뒤 새 약 이름이 결과에 포함되는지 검사했습니다. 이 PR 은 반대로 새 약을 한 번 조회해 병용금기 성분 집합을 얻고, 기존약들의 `component` 와 비교합니다. 호출 수를 N → 1 로 줄여 지연을 낮추는 효과가 있고, DUR 의 병용금기가 사실상 대칭(A‑B 와 B‑A 가 모두 등재)이라는 점에 기댑니다. 일부 쌍이 한 방향으로만 등재돼 있다면 놓칠 수 있는데, 표본에서는 발견되지 않았고 후속에서 양방향 조회로 보강할 수 있습니다.

#### 3. **양방향 contains 매칭**

`"이부프로펜 200mg"` 처럼 사용자약 성분에 용량·제형이 붙거나, 반대로 사용자가 더 일반적인 명칭("이부프로펜")으로 저장한 경우를 모두 흡수하기 위해 정규화 후 양쪽 모두 contains 를 확인합니다. 짧은 성분명이 다른 성분명에 우연히 포함되는 false positive 위험이 일부 있지만, 환자 안전 도메인 특성상 과탐(over-warn)이 미탐(missed)보다 안전하다는 판단으로 수용했습니다.

#### 4. **`component` 폴백**

DB 의 사용자 약이 과거 데이터·OCR 결과 등으로 `component` 없이 저장됐을 수 있어, 빈 경우 `medicineName` 으로 자연스럽게 폴백합니다. 이 경로는 이름 기반이라 정확도는 떨어지지만 동작이 끊기지 않습니다.

#### 5. **경고 문구의 정보량**

이전 엔진은 DUR 원문(`PROHBT_CONTENT` 등)을 그대로 노출했는데, 사용자에게 노출되는 메시지로는 과해서 단일 안내 문구로 단순화했습니다. 사유(횡문근융해증·혈액학적 독성 등)는 후속에서 `PROHBT_CONTENT` 를 함께 매핑해 풍부하게 보강할 여지가 있습니다.

#### 6. **캐싱 미적용**

매 요청마다 DUR API 를 호출합니다. 같은 약에 대한 반복 호출이 흔하다면 캐싱(예: Caffeine, Redis)으로 지연·쿼터를 줄일 수 있지만, 이번 변경 범위에서는 도입하지 않았습니다.

## 호환성 / 영향 범위

- `/v2/check` 응답 메시지 포맷이 바뀝니다. 요청·응답 스키마는 동일하고 문구만 단일 가이드 문구로 통일됩니다.
- `/v2/info` 는 영향이 없습니다. `lookupByMedicineName` 경로를 그대로 사용합니다.
- 포트에 메서드가 하나 추가됐고 구현체가 `DurInteractionRuleAdapter` 하나뿐이라 호환성 문제는 없습니다.

## 연관 이슈

Closes #74