### PR TITLE
[FEAT] 상호작용 경고에 병용금기 사유(PROHBT_CONTENT) 노출

### DIFF
--- a/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapter.java
@@ -10,9 +10,10 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.stereotype.Component;
 
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * 식약처 DUR 병용금기 기반 {@link InteractionRulePort} 구현
@@ -29,25 +30,33 @@ public class DurInteractionRuleAdapter implements InteractionRulePort {
 
     @Override
     public List<MedicineInteractResponseDto> lookupByMedicineName(String medicineName) {
-        Set<String> contraindicated = lookupContraindicatedIngredients(medicineName);
+        Map<String, String> contraindicated = lookupContraindicatedIngredients(medicineName);
         if (contraindicated.isEmpty()) {
             return List.of();
         }
+        // /info 표시용 문자열: 성분(사유) 포맷으로 결합. 사유가 비면 성분만
+        List<String> entries = new ArrayList<>();
+        for (Map.Entry<String, String> e : contraindicated.entrySet()) {
+            entries.add(e.getValue() == null || e.getValue().isBlank()
+                ? e.getKey()
+                : e.getKey() + "(" + e.getValue() + ")");
+        }
         return List.of(MedicineInteractResponseDto.builder()
             .name(medicineName)
-            .interactionWarnings(String.join(", ", contraindicated))
+            .interactionWarnings(String.join(", ", entries))
             .build());
     }
 
     @Override
-    public Set<String> lookupContraindicatedIngredients(String medicineName) {
+    public Map<String, String> lookupContraindicatedIngredients(String medicineName) {
         try {
             JSONArray items = client.fetchUsjntTabooByName(medicineName);
             if (items == null || items.isEmpty()) {
-                return Set.of();
+                return Map.of();
             }
 
-            Set<String> contraindicated = new LinkedHashSet<>();
+            // 같은 상대 성분에 여러 사유가 등재돼 있을 수 있어 첫 사유를 채택(putIfAbsent)
+            Map<String, String> contraindicated = new LinkedHashMap<>();
             for (Object o : items) {
                 if (!(o instanceof JSONObject it)) continue;
                 // 병용금기 상대 성분명 우선 (같은 성분의 제품이 여러 개라 성분 기준이 간결).
@@ -57,15 +66,15 @@ public class DurInteractionRuleAdapter implements InteractionRulePort {
                     MfdsMedicineClient.getString(it, "MIXTURE_ITEM_NAME"),
                     MfdsMedicineClient.getString(it, "MIXTURE_INGR_ENG_NAME")
                 );
-                if (mix != null && !mix.isBlank()) {
-                    contraindicated.add(mix);
-                }
+                if (mix == null || mix.isBlank()) continue;
+                String reason = MfdsMedicineClient.getString(it, "PROHBT_CONTENT");
+                contraindicated.putIfAbsent(mix, reason == null ? "" : reason);
             }
             return contraindicated;
 
         } catch (Exception e) {
             log.warn("DUR 병용금기 조회 실패 medicineName={}: {}", medicineName, e.getMessage());
-            return Set.of();
+            return Map.of();
         }
     }
 }

--- a/api/src/main/java/com/mediforme/mediforme/check/engine/InteractionEngine.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/engine/InteractionEngine.java
@@ -7,14 +7,13 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 /**
  * 약물 상호작용 계산 엔진
  *
  * 새 복용 예정 약의 병용금기 성분 집합을 한 번 조회한 뒤, 기존 복용 약의 성분(component)과
- * 정규화 비교한다. 이름이 아닌 성분 기준으로 매칭해 제품명·브랜드·용량 표기 차이를 흡수한다.
+ * 정규화 비교한다. 충돌 시 DUR `PROHBT_CONTENT`(사유)를 경고 문구에 함께 부착한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -30,33 +29,46 @@ public class InteractionEngine {
             return List.of();
         }
 
-        Set<String> contraindicated = rulePort.lookupContraindicatedIngredients(newMedication).stream()
-            .map(InteractionEngine::normalize)
-            .filter(s -> !s.isBlank())
-            .collect(Collectors.toSet());
-        if (contraindicated.isEmpty()) {
+        Map<String, String> reasons = rulePort.lookupContraindicatedIngredients(newMedication);
+        if (reasons.isEmpty()) {
+            return List.of();
+        }
+
+        // 정규화된 키 ↔ 원본 키·사유를 미리 묶어 둔다
+        List<Entry> entries = new ArrayList<>();
+        for (Map.Entry<String, String> e : reasons.entrySet()) {
+            String norm = normalize(e.getKey());
+            if (!norm.isBlank()) {
+                entries.add(new Entry(norm, e.getKey(), e.getValue() == null ? "" : e.getValue()));
+            }
+        }
+        if (entries.isEmpty()) {
             return List.of();
         }
 
         List<String> warnings = new ArrayList<>();
         for (MedicineInteractionDto userMed : userMeds) {
-            // 기존 약은 성분(component)을 우선 사용, 없으면 약 이름으로 대체
             String candidate = hasText(userMed.getComponent())
                 ? userMed.getComponent() : userMed.getMedicineName();
             if (!hasText(candidate)) {
                 continue;
             }
             String norm = normalize(candidate);
-            boolean conflict = contraindicated.stream()
-                .anyMatch(c -> norm.contains(c) || c.contains(norm));
-            if (conflict) {
+            Entry match = entries.stream()
+                .filter(e -> norm.contains(e.norm) || e.norm.contains(norm))
+                .findFirst()
+                .orElse(null);
+            if (match != null) {
+                String reasonSuffix = hasText(match.reason) ? "(" + match.reason + ")" : "";
                 warnings.add(String.format(
-                    "%s과(와) %s는 병용금기입니다. 함께 복용 전 의사·약사와 상담하세요.",
-                    userMed.getMedicineName(), newMedication));
+                    "%s과(와) %s는 병용금기입니다%s. 함께 복용 전 의사·약사와 상담하세요.",
+                    userMed.getMedicineName(), newMedication, reasonSuffix));
             }
         }
         return warnings;
     }
+
+    private record Entry(String norm, String original, String reason) {}
 
     private static String normalize(String s) {
         return s == null ? "" : s.toLowerCase().replaceAll("\\s+", "");

--- a/api/src/main/java/com/mediforme/mediforme/check/port/InteractionRulePort.java
+++ b/api/src/main/java/com/mediforme/mediforme/check/port/InteractionRulePort.java
@@ -3,7 +3,7 @@ package com.mediforme.mediforme.check.port;
 import com.mediforme.mediforme.medicine.dto.MedicineInteractResponseDto;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * 약 이름을 기반 해당 약의 상호작용 규칙/경고 조회 포트
@@ -16,7 +16,8 @@ public interface InteractionRulePort {
     List<MedicineInteractResponseDto> lookupByMedicineName(String medicineName);
 
     /**
-     * 주어진 약과 병용금기인 상대 성분명 집합 조회 (성분 충돌 검사용)
+     * 주어진 약과 병용금기인 상대 성분명 → 사유 매핑 조회 (성분 충돌 검사용)
+     * 키는 상대 성분명, 값은 병용금기 사유(`PROHBT_CONTENT`). 사유가 비어 있으면 빈 문자열
      */
-    Set<String> lookupContraindicatedIngredients(String medicineName);
+    Map<String, String> lookupContraindicatedIngredients(String medicineName);
 }

--- a/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/adapter/DurInteractionRuleAdapterTest.java
@@ -7,9 +7,10 @@ import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -17,11 +18,11 @@ import static org.mockito.Mockito.when;
 class DurInteractionRuleAdapterTest {
 
     @Test
-    void DUR_병용금기를_경고_문자열로_매핑한다() throws Exception {
+    void info_응답은_성분과_사유를_괄호로_묶어_노출한다() throws Exception {
         DurInteractionClient client = mock(DurInteractionClient.class);
         JSONArray items = new JSONArray();
-        items.add(item("메토트렉세이트"));
-        items.add(item("케토롤락트로메타민"));
+        items.add(item("메토트렉세이트", "혈액학적 독성"));
+        items.add(item("케토롤락트로메타민", "위장관 출혈 위험"));
         when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
 
         DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
@@ -30,8 +31,21 @@ class DurInteractionRuleAdapterTest {
         assertThat(rules).hasSize(1);
         assertThat(rules.get(0).getName()).isEqualTo("이부프로펜");
         assertThat(rules.get(0).getInteractionWarnings())
-            .contains("메토트렉세이트")
-            .contains("케토롤락트로메타민");
+            .contains("메토트렉세이트(혈액학적 독성)")
+            .contains("케토롤락트로메타민(위장관 출혈 위험)");
+    }
+
+    @Test
+    void 사유가_없으면_성분명만_노출한다() throws Exception {
+        DurInteractionClient client = mock(DurInteractionClient.class);
+        JSONArray items = new JSONArray();
+        items.add(item("메토트렉세이트", null));
+        when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
+
+        DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
+
+        assertThat(adapter.lookupByMedicineName("이부프로펜").get(0).getInteractionWarnings())
+            .isEqualTo("메토트렉세이트");
     }
 
     @Test
@@ -55,21 +69,38 @@ class DurInteractionRuleAdapterTest {
     }
 
     @Test
-    void 병용금기_상대_성분_집합을_반환한다() throws Exception {
+    void 병용금기_상대_성분과_사유_매핑을_반환한다() throws Exception {
         DurInteractionClient client = mock(DurInteractionClient.class);
         JSONArray items = new JSONArray();
-        items.add(item("메토트렉세이트"));
-        items.add(item("와파린"));
+        items.add(item("메토트렉세이트", "혈액학적 독성"));
+        items.add(item("와파린", "출혈 위험"));
         when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
 
         DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
-        Set<String> contraindicated = adapter.lookupContraindicatedIngredients("이부프로펜");
+        Map<String, String> reasons = adapter.lookupContraindicatedIngredients("이부프로펜");
 
-        assertThat(contraindicated).containsExactlyInAnyOrder("메토트렉세이트", "와파린");
+        assertThat(reasons).containsOnly(
+            entry("메토트렉세이트", "혈액학적 독성"),
+            entry("와파린", "출혈 위험")
+        );
     }
 
     @Test
-    void 예외시_성분_집합도_비어있다() throws Exception {
+    void 같은_성분이_여러번_나오면_첫_사유를_채택한다() throws Exception {
+        DurInteractionClient client = mock(DurInteractionClient.class);
+        JSONArray items = new JSONArray();
+        items.add(item("메토트렉세이트", "혈액학적 독성"));
+        items.add(item("메토트렉세이트", "신독성"));
+        when(client.fetchUsjntTabooByName("이부프로펜")).thenReturn(items);
+
+        DurInteractionRuleAdapter adapter = new DurInteractionRuleAdapter(client);
+
+        assertThat(adapter.lookupContraindicatedIngredients("이부프로펜"))
+            .containsOnly(entry("메토트렉세이트", "혈액학적 독성"));
+    }
+
+    @Test
+    void 예외시_성분_매핑도_비어있다() throws Exception {
         DurInteractionClient client = mock(DurInteractionClient.class);
         when(client.fetchUsjntTabooByName(anyString())).thenThrow(new RuntimeException("network"));
 
@@ -79,9 +110,12 @@ class DurInteractionRuleAdapterTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static JSONObject item(String mixtureIngrKorName) {
+    private static JSONObject item(String mixtureIngrKorName, String prohbtContent) {
         JSONObject o = new JSONObject();
         o.put("MIXTURE_INGR_KOR_NAME", mixtureIngrKorName);
+        if (prohbtContent != null) {
+            o.put("PROHBT_CONTENT", prohbtContent);
+        }
         return o;
     }
 }

--- a/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
+++ b/api/src/test/java/com/mediforme/mediforme/check/engine/InteractionEngineTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,7 +40,7 @@ class InteractionEngineTest {
     @Test
     @DisplayName("새 약의 병용금기 성분이 없으면 경고 없음")
     void evaluate_noContraindication_returnsEmpty() {
-        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of());
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Map.of());
         MedicineInteractionDto med = MedicineInteractionDto.builder()
             .medicineName("타이레놀").component("아세트아미노펜").build();
 
@@ -48,23 +48,42 @@ class InteractionEngineTest {
     }
 
     @Test
-    @DisplayName("기존 약 성분이 새 약의 병용금기에 있으면 경고 생성")
-    void evaluate_componentInContraindicated_producesAlert() {
+    @DisplayName("충돌 시 경고 문구에 사유(PROHBT_CONTENT)를 괄호로 부착")
+    void evaluate_includesReasonInWarning() {
         given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
-            .willReturn(Set.of("메토트렉세이트", "와파린"));
+            .willReturn(Map.of("메토트렉세이트", "혈액학적 독성", "와파린", "출혈 위험"));
         MedicineInteractionDto med = MedicineInteractionDto.builder()
             .medicineName("메토잘").component("메토트렉세이트").build();
 
         List<String> result = engine.evaluate(List.of(med), "이부프로펜");
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0)).contains("메토잘").contains("이부프로펜").contains("병용금기");
+        assertThat(result.get(0))
+            .contains("메토잘")
+            .contains("이부프로펜")
+            .contains("병용금기입니다(혈액학적 독성)");
+    }
+
+    @Test
+    @DisplayName("사유가 비어 있으면 경고는 사유 없이 생성")
+    void evaluate_emptyReason_warningWithoutSuffix() {
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
+            .willReturn(Map.of("메토트렉세이트", ""));
+        MedicineInteractionDto med = MedicineInteractionDto.builder()
+            .medicineName("메토잘").component("메토트렉세이트").build();
+
+        List<String> result = engine.evaluate(List.of(med), "이부프로펜");
+
+        assertThat(result).hasSize(1);
+        // 사유가 비면 "병용금기입니다(...)." 가 아니라 "병용금기입니다." 로 마침표가 바로 뒤따름
+        assertThat(result.get(0)).contains("병용금기입니다.");
     }
 
     @Test
     @DisplayName("성분 표기 차이(용량·공백)는 정규화로 매칭")
     void evaluate_normalizesComponent() {
-        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("메토트렉세이트"));
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
+            .willReturn(Map.of("메토트렉세이트", "혈액학적 독성"));
         MedicineInteractionDto med = MedicineInteractionDto.builder()
             .medicineName("메토잘정").component("메토트렉세이트 2.5mg").build();
 
@@ -74,7 +93,8 @@ class InteractionEngineTest {
     @Test
     @DisplayName("충돌하지 않는 성분은 경고 없음")
     void evaluate_noConflict_returnsEmpty() {
-        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("메토트렉세이트"));
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
+            .willReturn(Map.of("메토트렉세이트", "혈액학적 독성"));
         MedicineInteractionDto med = MedicineInteractionDto.builder()
             .medicineName("타이레놀").component("아세트아미노펜").build();
 
@@ -84,7 +104,8 @@ class InteractionEngineTest {
     @Test
     @DisplayName("component 가 없으면 약 이름으로 매칭")
     void evaluate_fallsBackToMedicineName() {
-        given(rulePort.lookupContraindicatedIngredients("이부프로펜")).willReturn(Set.of("와파린"));
+        given(rulePort.lookupContraindicatedIngredients("이부프로펜"))
+            .willReturn(Map.of("와파린", "출혈 위험"));
         MedicineInteractionDto med = MedicineInteractionDto.builder().medicineName("와파린").build();
 
         assertThat(engine.evaluate(List.of(med), "이부프로펜")).hasSize(1);


### PR DESCRIPTION
## 작업 개요

기존 상호작용 응답은 병용금기 상대 성분만 노출해 "왜 위험한지"를 알 수 없었습니다. DUR 응답의 `PROHBT_CONTENT`(횡문근융해증·혈액학적 독성 등)를 함께 매핑·노출해 사용자 이해도를 높였습니다.

## 주요 변경 사항

#### 1. **InteractionRulePort 시그니처 변경**

- `lookupContraindicatedIngredients(name)` 반환을 `Set<String>` → `Map<String, String>` (성분 → 사유)으로 변경
- `lookupByMedicineName` 시그니처는 유지

#### 2. **DurInteractionRuleAdapter 확장**

- 응답에서 `MIXTURE_INGR_KOR_NAME` 와 `PROHBT_CONTENT` 를 페어로 추출 (LinkedHashMap 으로 입력 순서 보존)
- 같은 성분이 여러 사유로 등재된 경우 첫 사유 채택 (`putIfAbsent`)
- `/info` 의 `interactionWarnings` 포맷을 `"성분(사유), ..."` 로 강화하고, 사유가 비면 성분만 노출

#### 3. **InteractionEngine 경고 문구 강화**

- 충돌 시 사유를 괄호로 부착: `"메토잘정과(와) 이부프로펜는 병용금기입니다(혈액학적 독성). 함께 복용 전 의사·약사와 상담하세요."`
- 사유가 비어 있으면 괄호 없이 기존 문구 유지
- 정규화·양방향 contains 매칭 로직은 그대로

#### 4. **테스트 갱신**

- `DurInteractionRuleAdapterTest`: `/info` 사유 포맷, 사유 없는 경우, 같은 성분 첫 사유 채택, 매핑 반환·예외 폴백
- `InteractionEngineTest`: 사유 부착·사유 비어 있을 때·정규화·`component` 폴백 케이스
- `:api:test` · `:app:compileJava` 통과

## 라이브 검증

실제 DUR 키로 end-to-end 확인.

- 조회: `이부프로펜` → 매핑 `메토트렉세이트 → 혈액학적 독성`
- 엔진: 기존약 `메토잘정`(component=메토트렉세이트) + 새 약 `이부프로펜` → `"메토잘정과(와) 이부프로펜는 병용금기입니다(혈액학적 독성). 함께 복용 전 의사·약사와 상담하세요."`

## 고민사항

#### 1. **포트 시그니처 교체 vs 새 메서드 추가**

기존 `Set<String>` 을 유지하고 사유 조회용 메서드를 별도로 두는 안도 가능했지만, 단일 구현(`DurInteractionRuleAdapter`)·단일 호출자(`InteractionEngine`)라 호환성 위험이 작고 시그니처를 한 번에 교체하는 편이 인터페이스를 깔끔히 유지한다고 판단했습니다.

#### 2. **같은 성분에 여러 사유가 있을 때**

DUR 응답에는 같은 상대 성분이 다른 사유로 여러 번 등재되는 경우가 있습니다. 결정적 동작을 위해 첫 사유를 채택(`putIfAbsent`)했습니다. 만약 사유 누락이 문제가 되면 `"사유1 / 사유2"` 로 결합하는 방식으로 바꿀 여지가 있습니다.

#### 3. **사유가 비어 있을 때의 출력**

`PROHBT_CONTENT` 가 비어 있는 행도 일부 존재합니다. 이 경우 괄호 없이 성분명만 노출해 가독성을 유지했습니다.

#### 4. **`/info` 응답 포맷 — DTO 구조 vs 문자열 enrich**

구조화된 응답으로 바꾸려면 DTO 변경과 클라이언트 영향이 발생합니다. 현재 클라이언트가 `interactionWarnings` 문자열을 그대로 렌더링하는 점을 고려해, DTO 는 그대로 두고 문자열에 사유를 함께 담는 방식을 택했습니다.

#### 5. **사유 텍스트 가공 여부**

`PROHBT_CONTENT` 는 짧은 의학 용어 한두 단어(횡문근융해증·혈액학적 독성 등)로 들어와 그대로 노출해도 자연스럽습니다. 별도 가공·축약 없이 원문 사유를 그대로 사용했습니다.

## 호환성 / 영향 범위

- `/v2/check` 경고 문구가 사유 포함 형태로 길어집니다. 요청·응답 스키마는 동일합니다.
- `/v2/info` 의 `interactionWarnings` 문자열 포맷이 `"성분(사유), ..."` 로 바뀝니다. 사유 없을 때는 기존과 동일하게 성분명만 노출됩니다.
- 포트 메서드 반환 타입이 변경됐지만 구현체·호출자가 모두 코드베이스 내라 외부 영향은 없습니다.

## 연관 이슈

Closes #76